### PR TITLE
Added "Re-Suppress Request Buttons" mapping

### DIFF
--- a/mappings/hide-request-button/README.md
+++ b/mappings/hide-request-button/README.md
@@ -36,5 +36,5 @@ For more examples, see the testing [Google Sheet](https://docs.google.com/spread
 
 ## Mappings
 
-- [masterHideLocations.json](matchingLocations.json): locations in WebPAC and Encore will be matched against the `text` value in this list and hidden if found. 
-- [encoreHideLocations.json](encoreMatchingLocations.json): in addition to the "master" list, locations in Encore will be substring matched against the `text` value in this list and hidden if found. 
+- [masterHideLocations.json](masterHideLocations.json): locations in WebPAC and Encore will be matched against the `text` value in this list and hidden if found. 
+- [encoreHideLocations.json](encoreHideLocations.json): in addition to the "master" list, locations in Encore will be substring matched against the `text` value in this list and hidden if found. 

--- a/mappings/hide-request-button/README.md
+++ b/mappings/hide-request-button/README.md
@@ -1,0 +1,39 @@
+# Re-Suppress Request Buttons
+
+## Description
+
+In order to implement item-level holds in Sierra, we were required to change existing "requestable" business logic. This resulted in the _Request_ button appearing in unintended records in WebPAC and Encore.
+  
+After contacting Innovative and confirming:
+
+> there is no way to have the system suppress the request button unless the item/bib is not requestable
+
+We decided to pursue hiding the _Request_ button via JavaScript. This repo contains the mappings used to hide the button.
+
+For more information, see JIRA ticket [DIS-79](https://jira.nypl.org/browse/DIS-79).
+
+## Examples
+
+These bibs are examples where the _Request_ button should be hidden:
+
+- https://nypl-sierra-test.iii.com/record=b10087932
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10087932
+- https://nypl-sierra-test.iii.com/record=b10114570
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10114570
+- https://nypl-sierra-test.iii.com/record=b10128739
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10128739
+- https://nypl-sierra-test.iii.com/record=b10139869
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10139869
+- https://nypl-sierra-test.iii.com/record=b101515480
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb101515480
+- https://nypl-sierra-test.iii.com/record=b10040821
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10040821
+- https://nypl-sierra-test.iii.com/record=b10032439
+  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10032439
+
+For more examples, see the testing [Google Sheet](https://docs.google.com/spreadsheets/d/1tKlxQCIBhwHfZI-A_v3aZGO3bHfo4Al6S_gxtty0zIE/edit#gid=412932731).
+
+## Mappings
+
+- [masterHideLocations.json](matchingLocations.json): locations in WebPAC and Encore will be matched against the `text` value in this list and hidden if found. 
+- [encoreHideLocations.json](encoreMatchingLocations.json): in addition to the "master" list, locations in Encore will be substring matched against the `text` value in this list and hidden if found. 

--- a/mappings/hide-request-button/README.md
+++ b/mappings/hide-request-button/README.md
@@ -17,19 +17,19 @@ For more information, see JIRA ticket [DIS-79](https://jira.nypl.org/browse/DIS-
 These bibs are examples where the _Request_ button should be hidden:
 
 - https://nypl-sierra-test.iii.com/record=b10087932
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10087932
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10087932
 - https://nypl-sierra-test.iii.com/record=b10114570
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10114570
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10114570
 - https://nypl-sierra-test.iii.com/record=b10128739
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10128739
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10128739
 - https://nypl-sierra-test.iii.com/record=b10139869
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10139869
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10139869
 - https://nypl-sierra-test.iii.com/record=b101515480
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb101515480
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb101515480
 - https://nypl-sierra-test.iii.com/record=b10040821
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10040821
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10040821
 - https://nypl-sierra-test.iii.com/record=b10032439
-  https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10032439
+  - https://nypl-encore-test.iii.com/iii/encore/record/C__Rb10032439
 
 For more examples, see the testing [Google Sheet](https://docs.google.com/spreadsheets/d/1tKlxQCIBhwHfZI-A_v3aZGO3bHfo4Al6S_gxtty0zIE/edit#gid=412932731).
 

--- a/mappings/hide-request-button/README.md
+++ b/mappings/hide-request-button/README.md
@@ -7,6 +7,7 @@ In order to implement item-level holds in Sierra, we were required to change exi
 After contacting Innovative and confirming:
 
 > there is no way to have the system suppress the request button unless the item/bib is not requestable
+> ~ Jun 12, 2017 -  Priscilla Borquez <pborquez@iii.com> -  
 
 We decided to pursue hiding the _Request_ button via JavaScript. This repo contains the mappings used to hide the button.
 

--- a/mappings/hide-request-button/encoreHideLocations.json
+++ b/mappings/hide-request-button/encoreHideLocations.json
@@ -1,0 +1,8 @@
+[
+  {
+    "text": "OFFSITE"
+  },
+  {
+    "text": "Request in Advance"
+  }
+]

--- a/mappings/hide-request-button/masterHideLocations.json
+++ b/mappings/hide-request-button/masterHideLocations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "text": "SASB - Milstein Division - Mezzanine"
+  },
+  {
+    "text": "SASB M1 - General Research - Room 315"
+  },
+  {
+    "text": "SASB M2 - General Research Room 315"
+  },
+  {
+    "text": "SASB M1 - Art & Architecture Rm 300"
+  },
+  {
+    "text": "SASB M2 - Art and Architecture - Room 300"
+  },
+  {
+    "text": "SASB - Manuscripts & Archives Rm 328"
+  },
+  {
+    "text": "Schomburg Center - Manuscripts & Archives"
+  },
+  {
+    "text": "TSD - Request in Advance at SASB - Rose Main Reading Room"
+  }
+]


### PR DESCRIPTION
Hi Kate & Shawn,

I attempted to document the "mapping" that we're currently using to hide the Request button in Sierra. Since this is a mapping with associated data requirements, I thought it should live in this repo.

Let me know your thoughts. Thanks!