### PR TITLE
For discussion: proposed npm test to check jsonld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Dependency directory
+# https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
+node_modules
+
+# Optional npm cache directory
+.npm

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "nypl-core",
+  "version": "1.0.0",
+  "description": "Models, mappings, and vocabularies for the NYPL Core ontology.",
+  "main": "n/a",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NYPL/nypl-core.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/NYPL/nypl-core/issues"
+  },
+  "homepage": "https://github.com/NYPL/nypl-core#readme",
+  "devDependencies": {
+    "chai": "^4.1.1",
+    "mocha": "^3.5.0"
+  }
+}

--- a/test/locations-json-test.js
+++ b/test/locations-json-test.js
@@ -1,0 +1,38 @@
+describe('location.json', function () {
+  it('should validate as json', function () {
+    let content = require('../vocabularies/json-ld/locations.json')
+    expect(content).to.be.a('object')
+  })
+
+  describe('@graph entries', function () {
+    let content = require('../vocabularies/json-ld/locations.json')
+
+    it('should be an array', function () {
+      expect(content['@graph']).to.be.a('array')
+    })
+
+    describe('each entry', function () {
+      it('should be an object ', function () {
+        content['@graph'].forEach(function (item) {
+          expect(item).to.be.a('object')
+        })
+      })
+
+      it('should have an @id', function () {
+        content['@graph'].forEach(function (item) {
+          expect(item['@id']).to.be.a('string')
+          expect(item['@id']).to.match(/^nyplLocation:\w+/)
+        })
+      })
+
+      it('should have 1 or 0 recapCustomerCodes', function () {
+        content['@graph'].forEach(function (item) {
+          // Only check recapCustomerCode if it's set; Null recap codes are okay
+          if (item['nypl:recapCustomerCode']) {
+            expect(item['nypl:recapCustomerCode']).to.be.a('object')
+          }
+        })
+      })
+    })
+  })
+})

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,0 +1,1 @@
+global.expect = require('chai').expect


### PR DESCRIPTION
This PR proposes we add a node test suite to this repo so that we can test certain expectations about mapping documents before deploying. The proposed workflow would be:

 * make changes to mappings locally
 * run `npm test`
 * if the tests succeed, everything we *expect* to be true about the mappings documents is verified, so we can safely deploy to master

Alternatively we could just connect Travis and catch errors after they're committed to `master` if testing locally is cumbersome.
