### PR TITLE
Add specific subfields to Subject literal mapping

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -656,38 +656,47 @@
     "paths": [
       {
         "marc": "600",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "610",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "611",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "630",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "648",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "650",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "651",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "653",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       },
       {
         "marc": "655",
+        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       }
     ]


### PR DESCRIPTION
Per https://jira.nypl.org/browse/SRCH-73, adds specific subfields to 'Subject literal' mapping used by `pcdm-store-updater`