### PR TITLE
SRCH-301: Restricting MARC subfields used for titleDisplay serialization.

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -755,7 +755,19 @@
     "jsonLdKey": "titleDisplay",
     "paths": [
       {
-        "marc": "245"
+        "marc": "245",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "f",
+          "g",
+          "h",
+          "k",
+          "n",
+          "p",
+          "s"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Some MARC subfields ($6 & potentially $8) were being erroneously included in the `titleDisplay` field. No subfields were being specified in the field-mapping-bib.json, so we can explicitly state the fields we want in order to exclude those we don't.