### PR TITLE
Srch 123

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -203,8 +203,8 @@
     ]
   },
   "Genre/Form literal": {
-    "pred": "",
-    "jsonLdKey": "",
+    "pred": "nypl:genreForm",
+    "jsonLdKey": "genreForm",
     "paths": [
       {
         "marc": "655",

--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -202,6 +202,17 @@
       }
     ]
   },
+  "Genre/Form literal": {
+    "pred": "",
+    "jsonLdKey": "",
+    "paths": [
+      {
+        "marc": "655",
+        "subfields": ["a", "b", "c", "v", "x", "y", "z"],
+        "description": "Genre/Form literal"
+      }
+    ]
+  },
   "Identifier": {
     "pred": "dcterms:identifier",
     "jsonLdKey": "identifier",
@@ -710,11 +721,6 @@
       },
       {
         "marc": "653",
-        "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
-        "description": "Subject Added Entry-Personal Name"
-      },
-      {
-        "marc": "655",
         "subfields": ["a", "b", "c", "d", "e", "g", "4", "v", "x", "y", "z"],
         "description": "Subject Added Entry-Personal Name"
       }


### PR DESCRIPTION
- Add Genre/Form (nypl:genreForm) – map from 655
- only use subfields: $a $b $c $v $x $y $z delimited by ' – '
- remove 655 mapping from Subject literal (dc:subject).
- Adding pred and jsonLdKey to Genre/Form literal.