### PR TITLE
Remove 590 mapping from field-mapping-bib

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -562,11 +562,6 @@
         "description": "Source of Description Note"
       },
       {
-        "marc": "590",
-        "subfields": [ "a" ],
-        "description": "Unknown"
-      },
-      {
         "marc": "591",
         "subfields": [ "a" ],
         "description": "Unknown"


### PR DESCRIPTION
The old 590 mapping is being deprecated.

https://jira.nypl.org/browse/SCC-154