### PR TITLE
Add catalogBibLocation prop to bib mapping

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -46,6 +46,15 @@
       }
     ]
   },
+  "Catalog bib location code": {
+    "pred": "nypl:catalogBibLocation",
+    "jsonLdKey": "catalogBibLocation",
+    "paths": [
+      {
+        "marc": "locations.code"
+      }
+    ]
+  },
   "Contents": {
     "pred": "dcterms:tableOfContents",
     "jsonLdKey": "tableOfContents",


### PR DESCRIPTION
Adds `nypl:catalogBibLocation` to `field-mapping-bib`, per:

https://jira.nypl.org/browse/SCC-283