### PR TITLE
Remove custom indexPropertyName from note

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -348,7 +348,6 @@
   },
   "Note": {
     "pred": "bf:note",
-    "indexPropertyName": "noteV2",
     "jsonLdKey": "note",
     "paths": [
       {


### PR DESCRIPTION
In support of some index tuning, moving the ES mapping for notes fields
from noteV2 to just note.

This is the change represented by pre-release `v1.19a`