### PR TITLE
Add bib field mappings for parallel fields

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -682,6 +682,44 @@
       }
     ]
   },
+  "Parallel series statement": {
+    "pred": "nypl:parallelSeriesStatement",
+    "jsonLdKey": "parallelSeriesStatement",
+    "paths": [
+      {
+        "marc": "880",
+        "subfields": ["3","a","x","v","l"],
+        "isParallelFor": "440"
+      },
+      {
+        "marc": "880",
+        "subfields": ["3","a","x","v","l"],
+        "isParallelFor": "490"
+      }
+    ]
+  },
+  "Parallel title": {
+    "pred": "nypl:parallelTitle",
+    "jsonLdKey": "parallelTitle",
+    "paths": [
+      {
+        "marc": "880",
+        "subfields": [ "a", "b" ],
+        "isParallelFor": "245"
+      }
+    ]
+  },
+  "Parallel title display": {
+    "pred": "nypl:parallelTitleDisplay",
+    "jsonLdKey": "parallelTitleDisplay",
+    "paths": [
+      {
+        "marc": "880",
+        "subfields": [ "a", "b", "c", "f", "g", "h", "k", "n", "p", "s" ],
+        "isParallelFor": "245"
+      }
+    ]
+  },
   "Part of": {
     "pred": "nypl:partOf",
     "jsonLdKey": "partOf",


### PR DESCRIPTION
Adds bib field mappings for parallel series statement, title, and title
display. Uses existing convention of specifying specific marc tag and
subfields to query, but introduces `isParallelFor` field to specify what
non-880 marc tag the field value should be considered a variant of. This
is essential for 1) determining *which* 880 field to use among
potentially many 880s (`isParallelFor` can be checked against $6 value),
and also 2) for relating parallel fields to the specific primary field
by occurance number (so multiple parallel titles relate index-wise to
primary titles).

https://jira.nypl.org/browse/SCC-248