### PR TITLE
Add new Contents mapping, Contents title mapping

### DIFF
--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -61,7 +61,17 @@
     "paths": [
       {
         "marc": "505",
-        "subfields": ["a"]
+        "subfields": ["a", "g", "r", "t"]
+      }
+    ]
+  },
+  "Contents title": {
+    "pred": "nypl:contentsTitle",
+    "jsonLdKey": "contentsTitle",
+    "paths": [
+      {
+        "marc": "505",
+        "subfields": ["t"]
       }
     ]
   },


### PR DESCRIPTION
Adds updated field-mapping-bib mapping for 'Contents' property (adds $r, $r, $t for "enhanced" values). Adds new mapping for 'Contents title', which duplicates `505 $t` to a separately stored property.