### PR TITLE
Add Cullman Scholar ptype, clarified serialization scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mappings/scripts/*/node_modules
+vocabularies/scripts/*.egg-info

--- a/vocabularies/csv/patronTypes.csv
+++ b/vocabularies/csv/patronTypes.csv
@@ -26,6 +26,7 @@ skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
 86,Wertheim Scholar,Research;Scholar
 87,Allen Scholar,Research;Scholar
 88,Shoichi Noma Scholar,Research;Scholar
+89,Cullman Scholar,Research;Scholar
 90,Organization (1 Year Only),Research
 91,(Non-MyLibraryNYC) NYC Educator,Research
 100,INACTIVE PATRON,Research

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -107,8 +107,8 @@
       "@id": "ptype:86",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
+        "Research",
+        "Scholar"
       ],
       "skos:notation": "86",
       "skos:prefLabel": "Wertheim Scholar"
@@ -148,6 +148,16 @@
       "skos:prefLabel": "Shoichi Noma Scholar"
     },
     {
+      "@id": "ptype:89",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "89",
+      "skos:prefLabel": "Cullman Scholar"
+    },
+    {
       "@id": "ptype:108",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
@@ -165,8 +175,8 @@
       "@id": "ptype:106",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
+        "Scholar",
+        "Research"
       ],
       "skos:notation": "106",
       "skos:prefLabel": "NYPL Department"

--- a/vocabularies/scripts/README.md
+++ b/vocabularies/scripts/README.md
@@ -1,3 +1,13 @@
 # Scripts
 
-Python 2.7 (not tested with Python 3) scripts for converting CSV vocabulary file to JSON-LD. These scripts require the third-party [rdflib library](https://github.com/RDFLib/rdflib) and the [rdflib-jsonld extension](https://github.com/RDFLib/rdflib-jsonld) to run.  
+Python 2.7 (not tested with Python 3) scripts for converting CSV vocabulary file to JSON-LD.
+
+## Installation
+
+Run the following to install dependencies:
+
+```
+cd vocabularies/scripts
+python setup.py develop
+```
+

--- a/vocabularies/scripts/README.md
+++ b/vocabularies/scripts/README.md
@@ -11,3 +11,12 @@ cd vocabularies/scripts
 python setup.py develop
 ```
 
+## Running
+
+Serialize scripts expect to be run from within this directory.
+
+For example, this will rebuild ../json-ld/accessMessages.json from ../csv/accessMessages.csv:
+
+```
+python serialize-accessMessages.py
+```

--- a/vocabularies/scripts/serialize-accessMessages.py
+++ b/vocabularies/scripts/serialize-accessMessages.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('accessMessages.csv')
+f = open('../csv/accessMessages.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -35,7 +35,7 @@ for r in reader:
 #            loc = rdflib.Literal(l)
 #            g.add( (accessMessage, nypl.locationType, loc))
 
-z = open('accessMessages.json', 'wb')
+z = open('../json-ld/accessMessages.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/serialize-catalogItemTypes.py
+++ b/vocabularies/scripts/serialize-catalogItemTypes.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('catalogItemTypes.csv')
+f = open('../csv/catalogItemTypes.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -40,7 +40,7 @@ for r in reader:
             l = rdflib.Literal(l)
             g.add( (catalogItemType, nypl.collectionType, l))
 
-z = open('catalogItemTypes.json', 'wb')
+z = open('../json-ld/catalogItemTypes.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#",

--- a/vocabularies/scripts/serialize-icode2.py
+++ b/vocabularies/scripts/serialize-icode2.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('icode2.csv')
+f = open('../csv/icode2.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -33,7 +33,7 @@ for r in reader:
         note = rdflib.Literal(r['skos:note'])
         g.add( (icode2, SKOS.note, note))
 
-z = open('icode2.json', 'wb')
+z = open('../json-ld/icode2.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/serialize-locations.py
+++ b/vocabularies/scripts/serialize-locations.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('locations.csv')
+f = open('../csv/locations.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -73,7 +73,7 @@ for r in reader:
         custcode = recapCustomerCode + str(r['nypl:recapCustomerCode'])
         g.add( (location, nypl.recapCustomerCode, custcode))
 
-z = open('locations.json', 'wb')
+z = open('../json-ld/locations.json', 'wb')
 
 context = {"dcterms": "http://purl.org/dc/terms/",
            "nypl": "http://data.nypl.org/nypl-core/",

--- a/vocabularies/scripts/serialize-organizations.py
+++ b/vocabularies/scripts/serialize-organizations.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('organizations.csv')
+f = open('../csv/organizations.csv')
 reader = csv.DictReader(f)
 
 org = Namespace('http://www.w3.org/ns/org#')
@@ -38,7 +38,7 @@ for r in reader:
             unit = nyplorg + u.strip()
             g.add( (orgunit, org.unitOf, unit))
 
-z = open('organizations.json', 'wb')
+z = open('../json-ld/organizations.json', 'wb')
 
 context = {"org": "http://www.w3.org/ns/org#",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/serialize-patronTypes.py
+++ b/vocabularies/scripts/serialize-patronTypes.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('patronTypes.csv')
+f = open('../csv/patronTypes.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -33,7 +33,7 @@ for r in reader:
             if a != '':
                 g.add( (ptype, nypl.deliveryLocationAccess, rdflib.Literal(a)))
 
-z = open('patronTypes.json', 'wb')
+z = open('../json-ld/patronTypes.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/serialize-recapCustomerCodes.py
+++ b/vocabularies/scripts/serialize-recapCustomerCodes.py
@@ -4,7 +4,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('recapCustomerCodes.csv')
+f = open('../csv/recapCustomerCodes.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -38,7 +38,7 @@ for r in reader:
                 d = custCode + d.strip()
                 g.add( (recapCustomerCode, nypl.deliverableTo, d))
 
-z = open('recapCustomerCodes.json', 'wb')
+z = open('../json-ld/recapCustomerCodes.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/serialize-statuses.py
+++ b/vocabularies/scripts/serialize-statuses.py
@@ -7,7 +7,7 @@ from rdflib.serializer import Serializer
 import rdflib
 import csv
 
-f = open('statuses.csv')
+f = open('../csv/statuses.csv')
 reader = csv.DictReader(f)
 
 nypl = Namespace('http://data.nypl.org/nypl-core/')
@@ -36,7 +36,7 @@ for r in reader:
         requestable = rdflib.Literal(requestable, datatype="XSD:boolean")
         g.add ( (status, nypl.requestable, requestable) )
 
-z = open('statuses.json', 'wb')
+z = open('../json-ld/statuses.json', 'wb')
 
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#", 

--- a/vocabularies/scripts/setup.py
+++ b/vocabularies/scripts/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+
+print "Installing dependencies for serialize scripts"
+
+setup(name='serializescripts',
+      version='1.0.0',
+      description='Various scripts for serializing CSV to JSON-LD',
+      author='Shawn Averkamp',
+      license='MIT',
+      install_requires=[
+          'rdflib',
+          'rdflib-jsonld',
+      ])
+


### PR DESCRIPTION
This:

 - Adds the new Cullman Scholar entry to the patronTypes vocabulary (as CSV & JSON-LD)
 - Adds a `vocabularies/scripts/setup.py` to assist dependency install
 - Changes CSV & JSON path in all serialize scripts so that updates can be made in-place, without copying files around.
 - Updates `vocabularies/scripts/README.md` to clarify use

This is tagged pre-release v1.23a