### PR TITLE
Add patron types 120, 121

### DIFF
--- a/vocabularies/csv/patronTypes.csv
+++ b/vocabularies/csv/patronTypes.csv
@@ -39,6 +39,8 @@ skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
 107,Partner Card - Columbia,Research
 108,Partner Card - Princeton,Research
 116,"NYPL Retiree, Non-NYS (3 Year)",Research
+120,Easy Borrowing AdultPilot,
+121,Easy Borrowing SeniorPilot,
 149,MyLibraryNYC Educator Queens,Research
 150,MyLibNYC Child 0-12 All Access,Research
 151,MyLibraryNYC Educator,Research

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -344,6 +344,20 @@
       ],
       "skos:notation": "76",
       "skos:prefLabel": "SASB Scholar RM 217"
+    },
+    {
+      "@id": "ptype:120",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [],
+      "skos:notation": "120",
+      "skos:prefLabel": "Easy Borrowing AdultPilot"
+    },
+    {
+      "@id": "ptype:121",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [],
+      "skos:notation": "121",
+      "skos:prefLabel": "Easy Borrowing SeniorPilot"
     }
   ]
 }


### PR DESCRIPTION
Add ptypes 120, 121, which are Easy Borrowing ptypes barred from placing holds.

Normally ptypes have `nypl:deliveryLocationAccess` with "Research" (and in some cases also "Scholar"). Ptypes 120 and 121 are ineligible for placing holds to *either* location. Hence, they are the first ptype to have empty `nypl:deliveryLocationAccess`. This property directly controls what delivery options are provided them in SCC. The empty`nypl:deliveryLocationAccess` will also trigger [a new "issue" check in the PatronEligibilityService](https://github.com/NYPL-discovery/patron-eligibility-service/pull/1)