### PR TITLE
Change: JS eddRequestable should be true

### DIFF
--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -35,7 +35,7 @@ ID,ID,Inter-Library Loan (deprecated),,false,0001
 JN,JN,JSTOR Standard,NB;ND;NF;NG;NH;NJ;NM;NP;SR;OA;OC;ON;OW;OD,true,0001
 JO,JO,JSTOR Restricted,NB;ND;NF;NG;NH;NJ;NM;NP;SR;OA;OC;ON;OW;OD,true,0001
 GO,GO,Google Project (deprecated),,false,0001
-JS,JS,SIBL De-duping candidates,NB;ND;NF;NG;NH;NJ;NM;NP;SR;OA;OC;ON;OW;OD,false,0001
+JS,JS,SIBL De-duping candidates,NB;ND;NF;NG;NH;NJ;NM;NP;SR;OA;OC;ON;OW;OD,true,0001
 OA,OA,SASB Allen Room,,false,0001
 OC,OC,SASB Cullman Center,,false,0001
 ON,ON,SASB Shoichi Noma Scholar Room,,false,0001

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -2485,7 +2485,7 @@
       ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "false"
+        "@value": "true"
       },
       "nypl:owner": {
         "@id": "nyplOrg:0001"


### PR DESCRIPTION
Per Heide, items with JS ReCAP customer code **should be** EDD requestable.

The pre-release tag for this change is now active in the QA DiscoveryAPI, allowing JS items in QA to offer EDD as a request option, e.g.:

http://qa-discovery.nypl.org/research/collections/shared-collection-catalog/hold/request/b12377228-i30611949