### PR TITLE
SCC-2206 Add Holdings Mapping Object

### DIFF
--- a/mappings/recap-discovery/field-mapping-holding.json
+++ b/mappings/recap-discovery/field-mapping-holding.json
@@ -11,10 +11,8 @@
                 "marc": "852",
                 "subfields": [
                     "k", "h", "i"
-                ]
-            },
-            {
-                "notes": "Above 852 fields should be joined to 'v' legacy field if present"
+                ],
+                "notes": "'v' legacy field should be appended to the 852 fields if present"
             }
         ]
     },
@@ -65,6 +63,9 @@
             },
             {
                 "notes": "Additional data drawn from the fieldTag 'h' fields"
+            },
+            {
+                "notes": "Pre-formatted statements also available in holdings.holding_statement field"
             }
         ]
     },
@@ -104,6 +105,20 @@
     },
     "Check In Box": {
         "predicate": "dcterms:hasPart",
-        "jsonLdKey": "checkInBoxes"
+        "jsonLdKey": "checkInBoxes",
+        "paths": [
+            {
+                "notes": "Drawn from enumeration, start_date and end_date fields"
+            }
+        ]
+    },
+    "Suppressed": {
+        "pred": "nypl:suppressed",
+        "jsonLdKey": "suppressed",
+        "paths": [
+            {
+                "notes": "set true if deleted or suppressed fields are set to true"
+            }
+        ]
     }
 }

--- a/mappings/recap-discovery/field-mapping-holding.json
+++ b/mappings/recap-discovery/field-mapping-holding.json
@@ -84,13 +84,14 @@
         "jsonLdKey": "format",
         "paths": [
             {
-                "notes": "Drawn from fieldTag 'i'"
+                "marc": "843",
+                "subfields": [
+                    "a"
+                ],
+                "notes": "With 843 present, fieldTag may be i or n"
             },
             {
-                "marc": "852",
-                "subfields": [
-                    "m"
-                ]
+                "notes": "Drawn from fieldTag 'i'"
             }
         ]
     },
@@ -99,7 +100,7 @@
         "jsonLdKey": "notes",
         "paths": [
             {
-                "notes": "Drawn from fieldTag 'n'"
+                "notes": "Drawn from fieldTag 'n', but not if marc field is 843"
             }
         ]
     },

--- a/mappings/recap-discovery/field-mapping-holding.json
+++ b/mappings/recap-discovery/field-mapping-holding.json
@@ -1,0 +1,109 @@
+{
+    "Identifier": {
+        "pred": "dcterms:identifier",
+        "jsonLdKey": "identifier"
+    },
+    "Call Number": {
+        "pred": "nypl:shelfMark",
+        "jsonLdKey": "shelfMark",
+        "paths": [
+            {
+                "marc": "852",
+                "subfields": [
+                    "k", "h", "i"
+                ]
+            },
+            {
+                "notes": "Above 852 fields should be joined to 'v' legacy field if present"
+            }
+        ]
+    },
+    "Physical Location": {
+        "pred": "bf:physicalLocation",
+        "jsonLdKey": "physicalLocation",
+        "paths": [
+            {
+                "marc": "852",
+                "subfields": [
+                    "k", "h", "i"
+                ]
+            }
+        ]
+    },
+    "Enumeration Chronology": {
+        "pred": "bf:enumerationAndChronology",
+        "jsonLdKey": "enumerationChronology",
+        "paths": [
+            {
+                "notes": "Drawn from 'v' legacy field"
+            }
+        ]
+    },
+    "Holding Statement": {
+        "pred": "dcterms:coverage",
+        "jsonLdKey": "holdingStatement",
+        "paths": [
+            {
+                "marc": "866",
+                "subfields": [
+                    "h"
+                ]
+            },
+            {
+                "marc": "853",
+                "subfields": [
+                    "8", "a", "b", "c", "d", "e", "f", "i", "j", "k", "l"
+                ],
+                "notes": "Provides structure for metadata in 863 fields"
+            },
+            {
+                "marc": "863",
+                "subfields": [
+                    "8", "a", "b", "c", "d", "e", "f", "i", "j", "k", "l"
+                ],
+                "notes": "Provides structured data as defined in 853 fields"
+            },
+            {
+                "notes": "Additional data drawn from the fieldTag 'h' fields"
+            }
+        ]
+    },
+    "Location": {
+        "pred": "nypl:holdingLocation",
+        "jsonLdKey": "location",
+        "paths": [
+            {
+                "marc": "Location",
+                "notes": "derived from location code stored in record"
+            }
+        ]
+    },
+    "Format": {
+        "pred": "dcterms:format",
+        "jsonLdKey": "format",
+        "paths": [
+            {
+                "notes": "Drawn from fieldTag 'i'"
+            },
+            {
+                "marc": "852",
+                "subfields": [
+                    "m"
+                ]
+            }
+        ]
+    },
+    "Note": {
+        "pred": "bf:note",
+        "jsonLdKey": "notes",
+        "paths": [
+            {
+                "notes": "Drawn from fieldTag 'n'"
+            }
+        ]
+    },
+    "Check In Box": {
+        "predicate": "dcterms:hasPart",
+        "jsonLdKey": "checkInBoxes"
+    }
+}


### PR DESCRIPTION
This adds a new mapping object to represent holdings records in the `discovery-store` and potentially other places that rely on these models.

Holdings objects are relatively simple and can be represented largely by relying on fields drawn from Bibframe. The mapping here draws heavily on the `item` mapping as the role and relationship between `bib` records and `items`/`holdings` is largely analogous.

Two important notes:

- The `Check In Box` field represents a blank node that contains data from the check-in cards. As these records are very simple, and are dependent on metadata from the `holding` record, this seemed like the best solution. It also avoids introducing a new relationship into the `discovery-store` that would complicate record retrieval
- This adds two new fields to handle components of the `shelfMark` field as independent parts, which is necessary to support additional designs in the SCC front-end. These new fields use Bibframe mappings, specifically `bf:physicalLocation` for the core part of the call number and `bf:enumerationAndChronology` for the components that define a specific section of the item at the call number. This division should also be added to the `item` mapping to go along with the extended `shelfMark` mapping that is under consideration to make working with this data easier. That will take place in a separate PR though.

I believe that this extension generally conforms to the NYPL Core Ontology, though it does make use of new fields that should be documented. Specifically the `Item` class in the ontology would have to be extended with these fields:

- Physical Location
- Enumeration/Chronology
- Coverage
- Has Part