### PR TITLE
SCC-2206 Fix two minor issues in holdings mapping

### DIFF
--- a/mappings/recap-discovery/field-mapping-holding.json
+++ b/mappings/recap-discovery/field-mapping-holding.json
@@ -10,9 +10,8 @@
             {
                 "marc": "852",
                 "subfields": [
-                    "k", "h", "i"
-                ],
-                "notes": "'v' legacy field should be appended to the 852 fields if present"
+                    "k", "h", "i", "n", "z"
+                ]
             }
         ]
     },
@@ -105,7 +104,7 @@
         ]
     },
     "Check In Box": {
-        "predicate": "dcterms:hasPart",
+        "pred": "dcterms:hasPart",
         "jsonLdKey": "checkInBoxes",
         "paths": [
             {


### PR DESCRIPTION
This corrects two minor issues in the holdings mapping that have been uncovered in testing the `discovery-store-poster`

1) The `852` Call Number/ShelfMark field was slightly misconfigured. This should NOT use the legacy `v` field in the way that Bib and Item records do, as they are cataloged differently, and two `852` subfields were omitted from the mapping.
2) The Check In Box mapping used `predicate` instead of `pred` which is a simple typo