### PR TITLE
SCC-2236 & SCC-2235 Update Item Mapping

### DIFF
--- a/mappings/recap-discovery/field-mapping-item.json
+++ b/mappings/recap-discovery/field-mapping-item.json
@@ -47,7 +47,11 @@
     "jsonLdKey": "shelfMark",
     "paths": [
       {
-        "notes": "Join 852$h and fieldTag 'v' value (if available) with a space"
+        "marc": "852",
+        "subfields": [
+          "k", "h", "i"
+        ],
+        "notes": "Join 852 $k $h $i fields and fieldTag 'v' value (if available) with a space"
       },
       {
         "marc": "945",

--- a/mappings/recap-discovery/field-mapping-item.json
+++ b/mappings/recap-discovery/field-mapping-item.json
@@ -59,6 +59,27 @@
       }
     ]
   },
+  "Enumeration Chronology": {
+    "pred": "bf:enumerationAndChronology",
+    "jsonLdKey": "enumerationChronology",
+    "paths": [
+        {
+            "notes": "Standalone representation of the 'v' fieldTag"
+        }
+    ]
+  },
+  "Physical Location": {
+    "pred": "bf:physicalLocation",
+    "jsonLdKey": "physicalLocation",
+    "paths": [
+        {
+            "marc": "852",
+            "subfields": [
+                "k", "h", "i"
+            ]
+        }
+    ]
+  },
   "Carrier type": {
     "pred": "bf:carrier",
     "jsonLdKey": "carrier",


### PR DESCRIPTION
This incorporates to updates to the `Item` mapping in `nypl-core` to support better display of Call Number data in SCC. These changes are:

1) The first is a bug fix to address issues with missing components in the `shelfMark` field, specifically to make sure that the `k` and `i` prefix and suffix fields are included in the `shelfMark` generation. This is necessary because these fields are displayed in the classic catalog
2) The second is an extension that adds two new fields to represent `shelfMark` metadata in new SCC designs for `Items`. These split the components into to separate fields that represent the physical location and as well as the coverage of each item. These fields can then be split into separate columns in the front-end. This does not remove the main `shelfMark` field, so this is an additive change that should not require updates to any components.