### PR TITLE
Remove mal23 from csv, jsonld

### DIFF
--- a/vocabularies/csv/locations.csv
+++ b/vocabularies/csv/locations.csv
@@ -1659,7 +1659,6 @@ mak82,SASB M1 - Periodicals Rm 108,SASB M1 - Periodicals Rm 108,Research,,,ma,,f
 makk3,Schwarzman Building - Dewitt Wallace Reference Desk Room 108,SASB - Dewitt Wallace Reference Desk Rm 108,Research,,,ma,1000,false,mak,,true,
 mal,Schwarzman Building - Main Reading Room 315,SASB - Service Desk Rm 315,Research,Research,,ma,1000,false,mal,NH,true,general-research-division
 mal17,Schwarzman Building - Scholar Room 217,SASB - Scholar Room 217,Research,Scholar,,ma,1000,false,,OD,,
-mal23,Schwarzman Building - Scholar Room 223,SASB - Scholar Room 223,Research,Scholar,,ma,1000,false,,OE,,
 mal72,SASB - SIBL - General Research - Room 315,SASB - SIBL - General Research - Room 315,Research,,,ma,,false,,,true,
 mal82,Schwarzman Building - Main Reading Room 315,SASB M1 - General Research - Room 315,Research,,,ma,1000,false,mab;mag;map;maf;mal;mai;mala;malc;maln;malw;mal17,,true,
 mal92,Schwarzman Building M2 - General Research Room 315,SASB M2 - General Research Room 315,Research,,,ma,1101,false,mab;mag;map;maf;mal;mai;mala;malc;maln;malw;mal17,,true,

--- a/vocabularies/json-ld/locations.json
+++ b/vocabularies/json-ld/locations.json
@@ -45731,28 +45731,6 @@
       "skos:prefLabel": "Webster YA Non-Print Media"
     },
     {
-      "@id": "nyplLocation:mal23",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
-      },
-      "nypl:collectionType": "Research",
-      "nypl:deliveryLocationType": "Scholar",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1000"
-      },
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "SASB - Scholar Room 223",
-      "skos:notation": "mal23",
-      "skos:prefLabel": "Schwarzman Building - Scholar Room 223"
-    },
-    {
       "@id": "nyplLocation:nby0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {


### PR DESCRIPTION
Remove mal23 from csv and json-ld. Previously, it was only removed from the json-ld, so its presence in the CSV caused it to resurface in the jsonld starting with v1.32.

This is tagged v1.33a