### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ NYPL-Core contains vocabularies and mappings that control many different compone
 2. If modifying `./vocabularies`, make your edits to the CSVs and then update the JSON-LD files using the included [`./vocabularies/scripts`](./vocabularies/scripts)
 3. (If modifying `./mappings`, you can just edit the JSONs directly.)
 4. Commit your changes.
-5. Create a pre-release tag using the next logical version number (e.g. if the current version is 1.32, run `git tag -a v1.33a`. See [Working with Git tags](#working-with-git-tags))
-6. Git push your feature branch (and push your tags via `git push --tags`) and create a PR
+5. Create a pre-release tag using the next logical version number (e.g. `v1.33a`. See [Working with Git tags](#working-with-git-tags))
+6. Git push and create a PR
 
 ### 2. Consider downstream effects
 
@@ -39,11 +39,11 @@ After 1) PR signoff and 2) confirming that your changes don't create trouble for
 1. Merge your PR and delete feature branch.
 2. Update [README.md](README.md) with the new version number
 3. Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes
-5. Commit your changes
-6. Add a release tag (e.g. `v1.33`)
-7. Push to master
-4. Add release notes at https://github.com/NYPL/nypl-core/tags .
-8. If you made changes to `./vocabularies`, [publish nypl-core-objects](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
+4. Commit your changes
+5. Add a release tag (e.g. `v1.33`)
+6. Push to master
+7. Add release notes at https://github.com/NYPL/nypl-core/tags .
+8. If you made changes to `./vocabularies`, [publish nypl-core-objects lookups to "production" S3](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
 
 ## Appendix
 

--- a/README.md
+++ b/README.md
@@ -6,60 +6,79 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 v1.32
 
-## Deployment Process
+## Contributing
 
-A suggested workflow for the `discovery-api` Beanstalk application.
-Deploying other apps that depend on `nypl-core` will resemble
-these steps in spirit.
+NYPL-Core contains vocabularies and mappings that control many different components across the Library Services Platform. It's important to follow these guidelines to reduce risk of unintended effects downstream.
 
-### General Workflow for Changes
+### 1. Propose your change
 
-* Create a new branch from master
-* Change the CSV file(s) with the intended changes
-* Serialize changes via the appropriate script(s)
-* Commit changes
-* Create a pre-release tag in the form vX.Xa, i.e. v1.1a
+1. Cut a feature branch from `master` with your intended change.
+2. If modifying `./vocabularies`, make your edits to the CSVs and then update the JSON-LD files using the included [`./vocabularies/scripts`](./vocabularies/scripts)
+3. (If modifying `./mappings`, you can just edit the JSONs directly.)
+4. Commit your changes.
+5. Create a pre-release tag using the next logical version number (e.g. if the current version is 1.32, run `git tag -a v1.33a`. See [Working with Git tags](#working-with-git-tags))
+6. Git push your feature branch (and push your tags via `git push --tags`) and create a PR
 
-#### For QA:
+### 2. Consider downstream effects
 
-* Test the pre-release tag on AWS nypl-sandbox by setting the
-  NYPL_CORE_VERSION variable to vX.Xa for applications that need to test
-  the changes
-* Change environment variables for `discovery-api-dev` (Elastic Beanstalk)
-* Apply the changes which will trigger an application restart
-* If no changes to variables are detected, a restart will not take
-  place. One must force a restart to clear caches and pull in changes.
-  For discovery-api, use the 'Restart App Server(s)' option in the Actions
-  dropdown.
-* Test the changes on our QA server
-* Make adjustments to the mapping as needed
-* Force update the tag via `git tag -f vX.Xa`
-* Restart the `discovery-api-dev` application
-* Re-test
+Think about what components are affected by the change. For changes to `./mappings`, you should consider the impact on components in the Discovery data pipeline. (Presumably you're making changes specifically for that pipeline.) For some `./vocabularies` changes (e.g. changes to `locations.json` or `recapCustomerCodes.json`) the components impacted are too many to independently test. At a minimum, you should check the following components:
 
-#### Multiple Pre-release Tags:
-If so desired, pre-release tags could be incremented by their trailing letter
-when working with multiple features for the same release.
-* Create a new pre-release tag vX.Xb when incorporating a secondary feature
-  for the same release
-* Follow the same restart, re-test, update loop for changes
+1. Verify that [nypl-core-objects](https://github.com/NYPL/nypl-core-objects) is able to parse your changes (e.g. to build local mappings files based on your pre-release tag of 1.33a, run `NYPL_CORE_VERSION=v1.33a npm run build-mappings` inside that repo)
+2. Verify that the specific component(s) for which you're making the change pick up the change...
 
-#### For Production:
+The method by which you verify an NYPL-Core change in an app depends on how the app includes NYPL-Core.
+* _For Node apps using `nypl-core-objects`_, you should be able to set `NYPL_CORE_VERSION=v1.33a` to tell it to use your pre-release version.
+* For (typically non-Node) _components that draw on S3-hosted lookup files_ (e.g. [by_sierra_location.json](https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json), you may test your change by first [deploying your pre-release vocab to the QA S3 bucket](https://github.com/NYPL/nypl-core-objects#pushing-to-s3) and then using the QA version of the S3-hosted file to verify your changes.
 
-* Create a pull request against master for your branch's changes
-* Submit for approval
-* Once approved, merge changes to master
-* Delete working branch
-* Update the README with the new version if the version has changed
-* Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes and push to master. Add release notes at https://github.com/NYPL/nypl-core/tags .
-* Add a release tag vX.X (without the trailing letter) based on the new
-  merge and commit
-* Restart the `discovery-api` application to clear the cache and pick up the
-  changes via the 'Restart App Server(s)' option in the Actions dropdown.
+Note that beanstalk apps may need to be "Restart"ed to pick up env config changes.
 
+### 3. Publish changes
 
-### Responsibilities
+After 1) PR signoff and 2) confirming that your changes don't create trouble for [nypl-core-objects](https://github.com/NYPL/nypl-core-objects) or other immediately impacted apps, proceed to publish.
 
-Contributors make changes, commit and submit pull requests. Approvals
-are performed by contributors other than the owners of pull requests.
-Owners of pull requests merge their changes upon approval.
+1. Merge your PR and delete feature branch.
+2. Update [README.md](README.md) with the new version number
+3. Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes
+5. Commit your changes
+6. Add a release tag (e.g. `v1.33`)
+7. Push to master
+4. Add release notes at https://github.com/NYPL/nypl-core/tags .
+8. If you made changes to `./vocabularies`, [publish nypl-core-objects](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
+
+## Appendix
+
+### Working with Git tags
+
+We [tend to tag version numbers starting with "v1.0.0"](https://github.com/NYPL/engineering-general/blob/master/standards/versioning.md). NYPL-Core diverges from that by only specifying major and minor precision (e.g. v1.33).
+
+To create a tag:
+
+```
+git tag v1.33
+```
+
+To create a "pre-release tag" (i.e. an unofficial version number tag published for the purpose of testing):
+
+```
+git tag v1.33a
+```
+
+After creating a pre-release tag (or any other tag), if you want to add additional commits to the tag (essentially reassign what the tag is an alias for), you'll need to force it:
+
+```
+git tag v1.33a -f
+```
+
+All tags you create must be pushed to origin after pushing your commits:
+
+```
+git push --tags
+```
+
+If you recently reassigned a pre-release tag, you'll need to force push:
+
+```
+git push --tags -f
+```
+
+Sometimes multiple features are vying for the next release version. If, when creating your pre-release tag, another active PR has already pushed code using that pre-release tag, you may create a second pre-release tag (e.g. `v1.33b`). You may arrange to eventually merge both features into the final release. Or only one feature may be rolled out under the version number and the other feature will have to take the next logical version number.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Note that beanstalk apps may need to be "Restart"ed to pick up env config change
 After 1) PR signoff and 2) confirming that your changes don't create trouble for [nypl-core-objects](https://github.com/NYPL/nypl-core-objects) or other immediately impacted apps, proceed to publish.
 
 1. Merge your PR and delete feature branch.
-2. Update [README.md](README.md) with the new version number
+2. Update [README.md](README.md#current-version) with the new version number (e.g. "v1.33")
 3. Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes
 4. Commit your changes
-5. Add a release tag (e.g. `v1.33`)
+5. Add a release tag (e.g. `v1.33`. See [Working with Git tags](#working-with-git-tags))
 6. Push to master
 7. Add release notes at https://github.com/NYPL/nypl-core/tags .
 8. If you made changes to `./vocabularies`, [publish nypl-core-objects lookups to "production" S3](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
@@ -54,19 +54,19 @@ We [tend to tag version numbers starting with "v1.0.0"](https://github.com/NYPL/
 To create a tag:
 
 ```
-git tag v1.33
+git tag -a v1.33
 ```
 
 To create a "pre-release tag" (i.e. an unofficial version number tag published for the purpose of testing):
 
 ```
-git tag v1.33a
+git tag -a v1.33a
 ```
 
 After creating a pre-release tag (or any other tag), if you want to add additional commits to the tag (essentially reassign what the tag is an alias for), you'll need to force it:
 
 ```
-git tag v1.33a -f
+git tag -a v1.33a -f
 ```
 
 All tags you create must be pushed to origin after pushing your commits:


### PR DESCRIPTION
This is an attempt to clarify the README's coverage of how one contributes to mappings and vocabularies in NYPL-Core. The former README was oriented around discovery-api without touching on other consumers. This version tries to cover downstream effects generally and - hopefully - provide a clearer sense of the process.