### PR TITLE
Add Harvard Library to organizations

### DIFF
--- a/vocabularies/csv/organizations.csv
+++ b/vocabularies/csv/organizations.csv
@@ -2,6 +2,7 @@ code,id,rdf:type,skos:prefLabel,skos:altLabel,org:unitOf
 NYPL,0001,org:Organization,New York Public Library,,
 CUL,0002,org:Organization,Columbia University Libraries,,
 PUL,0003,org:Organization,Princeton University Library,,
+HL,0004,org:Organization,Harvard Library,,
 ,1000,org:OrganizationalUnit,Stephen A. Schwarzman Building,,http://data.nypl.org/orgs/0001
 ,1001,org:OrganizationalUnit,Schomburg Center for Research in Black Culture,,http://data.nypl.org/orgs/0001
 ,1002,org:OrganizationalUnit,"New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center",,http://data.nypl.org/orgs/0001

--- a/vocabularies/json-ld/organizations.json
+++ b/vocabularies/json-ld/organizations.json
@@ -199,6 +199,12 @@
       "skos:prefLabel": "Columbia University Libraries"
     },
     {
+      "@id": "nyplOrg:0004",
+      "@type": "org:OrganizationalUnit",
+      "skos:notation": "HL",
+      "skos:prefLabel": "Harvard Library"
+    },
+    {
       "@id": "nyplOrg:1129",
       "@type": "org:OrganizationalUnit",
       "skos:altLabel": "Slavic and East European Collections",


### PR DESCRIPTION
Mints a new id to represent Harvard Library (HL) as an organization.

This allows us to identify the organization associated with Harvard
records by id.

https://jira.nypl.org/browse/SCC-2719