### PR TITLE
Add nypl source mapping

### DIFF
--- a/mappings/recap-discovery/nypl-source-mapping.json
+++ b/mappings/recap-discovery/nypl-source-mapping.json
@@ -2,6 +2,7 @@
   "sierra-nypl": {
     "organization": "nyplOrg:0001",
     "bibPrefix": "b",
+    "holdingPrefix": "h",
     "itemPrefix": "i"
   },
   "recap-pul": {

--- a/mappings/recap-discovery/nypl-source-mapping.json
+++ b/mappings/recap-discovery/nypl-source-mapping.json
@@ -1,0 +1,22 @@
+{
+  "sierra-nypl": {
+    "organization": "nyplOrg:0001",
+    "bibPrefix": "b",
+    "itemPrefix": "i"
+  },
+  "recap-pul": {
+    "organization": "nyplOrg:0003",
+    "bibPrefix": "pb",
+    "itemPrefix": "pi"
+  },
+  "recap-cul": {
+    "organization": "nyplOrg:0002",
+    "bibPrefix": "cb",
+    "itemPrefix": "ci"
+  },
+  "recap-hl": {
+    "organization": "nyplOrg:0004",
+    "bibPrefix": "hb",
+    "itemPrefix": "hi"
+  }
+}


### PR DESCRIPTION
This adds a new "recap-discovery" mapping file to centralize mapping nyplSource identifiers (e.g. "sierra-nypl", "recap-pul") to record identifier prefixes (e.g. "b", "pb") used throughout Discovery Data pipeline.

See https://github.com/NYPL-discovery/discovery-store-models/blob/scc-2719/lib/nypl-source-mapper.js for a util using this data.

This is v1.37a

https://jira.nypl.org/browse/SCC-2719