### PR TITLE
Revise workflow to update CHANGELOG in PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ After 1) PR signoff and 2) confirming that your changes don't create trouble for
 2. Commit your changes
 3. Add a release tag (e.g. `v1.33`. See [Working with Git tags](#working-with-git-tags))
 4. Push to master
-5. If you made changes to `./vocabularies`, follow the instructions in [nypl-core-objects "Pushing to S3"](https://github.com/NYPL/nypl-core-objects#pushing-to-s3) to push updated JSONs to S3 (for use by non-Node apps).
-
+5. If you made changes to `./vocabularies`:
+   - Follow the instructions in [nypl-core-objects "Pushing to S3"](https://github.com/NYPL/nypl-core-objects#pushing-to-s3) to push updated JSONs to S3 (for use by non-Node apps).
+   - If there are Node apps that need your update, update their `NYPL_CORE_VERSION` to your new version (e.g. `v1.33`)
+   
 ## Appendix
 
 ### Working with Git tags

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ After 1) PR signoff and 2) confirming that your changes don't create trouble for
 2. Commit your changes
 3. Add a release tag (e.g. `v1.33`. See [Working with Git tags](#working-with-git-tags))
 4. Push to master
-5. Add release notes at https://github.com/NYPL/nypl-core/tags .
-6. If you made changes to `./vocabularies`, [publish nypl-core-objects lookups to "production" S3](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
+5. If you made changes to `./vocabularies`, follow the instructions in [nypl-core-objects "Pushing to S3"](https://github.com/NYPL/nypl-core-objects#pushing-to-s3) to push updated JSONs to S3 (for use by non-Node apps).
 
 ## Appendix
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ NYPL-Core contains vocabularies and mappings that control many different compone
 1. Cut a feature branch from `master` with your intended change.
 2. If modifying `./vocabularies`, make your edits to the CSVs and then update the JSON-LD files using the included [`./vocabularies/scripts`](./vocabularies/scripts)
 3. (If modifying `./mappings`, you can just edit the JSONs directly.)
-4. Commit your changes.
-5. Create a pre-release tag using the next logical version number (e.g. `v1.33a`. See [Working with Git tags](#working-with-git-tags))
-6. Git push and create a PR
+4. Update [README.md](README.md#current-version) with the new version number (e.g. "v1.33")
+5. Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes
+6. Commit your changes.
+7. Create a pre-release tag using the next logical version number (e.g. `v1.33a`. See [Working with Git tags](#working-with-git-tags))
+8. Git push and create a PR
 
 ### 2. Consider downstream effects
 
@@ -37,13 +39,11 @@ Note that beanstalk apps may need to be "Restart"ed to pick up env config change
 After 1) PR signoff and 2) confirming that your changes don't create trouble for [nypl-core-objects](https://github.com/NYPL/nypl-core-objects) or other immediately impacted apps, proceed to publish.
 
 1. Merge your PR and delete feature branch.
-2. Update [README.md](README.md#current-version) with the new version number (e.g. "v1.33")
-3. Add an entry to [CHANGELOG.md](CHANGELOG.md) summarizing the changes
-4. Commit your changes
-5. Add a release tag (e.g. `v1.33`. See [Working with Git tags](#working-with-git-tags))
-6. Push to master
-7. Add release notes at https://github.com/NYPL/nypl-core/tags .
-8. If you made changes to `./vocabularies`, [publish nypl-core-objects lookups to "production" S3](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
+2. Commit your changes
+3. Add a release tag (e.g. `v1.33`. See [Working with Git tags](#working-with-git-tags))
+4. Push to master
+5. Add release notes at https://github.com/NYPL/nypl-core/tags .
+6. If you made changes to `./vocabularies`, [publish nypl-core-objects lookups to "production" S3](https://github.com/NYPL/nypl-core-objects#pushing-to-s3)
 
 ## Appendix
 


### PR DESCRIPTION
This changes the following contributing/workflow concerns in the README:
 - Moves the README and CHANGELOG update to earlier in the process so that those changes are part of the PR (more typical and works around a branch protection rule on `master`)
 - Remove step about adding a description to the tagged release, as we haven't done that in a while and it never served a strong purpose.
 - Clarify final step regarding pushing changes to S3 through nypl-core-objects