### PR TITLE
Add ptype 75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### v1.41
+- Add new ptype 75 for Schomburg Scholar
+
 ### v1.40
 - Add missing HL Customer Code HV
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.40
+v1.41
 
 ## Contributing
 

--- a/vocabularies/csv/patronTypes.csv
+++ b/vocabularies/csv/patronTypes.csv
@@ -16,6 +16,7 @@ skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
 70,Disabled Metro NY (3 Year),Research
 72,Homebound NYC (3 Year),Research
 73,Homebound Juv Only NYC (3 Year),Research
+75,Schomburg Scholar,Research;Scholar
 76,SASB Scholar RM 217,Research;Scholar
 78,Short Term Scholar,Research;Scholar
 80,CUNY Graduate Center (9/30),Research

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -7,122 +7,18 @@
   },
   "@graph": [
     {
-      "@id": "ptype:51",
+      "@id": "ptype:10",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "51",
-      "skos:prefLabel": "Teen 13-17 NY State"
+      "skos:notation": "10",
+      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
     },
     {
-      "@id": "ptype:50",
+      "@id": "ptype:61",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "50",
-      "skos:prefLabel": "Teen 13-17 Metro"
-    },
-    {
-      "@id": "ptype:78",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "78",
-      "skos:prefLabel": "Short Term Scholar"
-    },
-    {
-      "@id": "ptype:31",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "31",
-      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
-    },
-    {
-      "@id": "ptype:30",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "30",
-      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
-    },
-    {
-      "@id": "ptype:73",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "73",
-      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
-    },
-    {
-      "@id": "ptype:72",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "72",
-      "skos:prefLabel": "Homebound NYC (3 Year)"
-    },
-    {
-      "@id": "ptype:70",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "70",
-      "skos:prefLabel": "Disabled Metro NY (3 Year)"
-    },
-    {
-      "@id": "ptype:100",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "100",
-      "skos:prefLabel": "INACTIVE PATRON"
-    },
-    {
-      "@id": "ptype:82",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "82",
-      "skos:prefLabel": "Scholar"
-    },
-    {
-      "@id": "ptype:83",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "83",
-      "skos:prefLabel": "Temporary (3 Day Research Only)"
-    },
-    {
-      "@id": "ptype:80",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "80",
-      "skos:prefLabel": "CUNY Graduate Center (9/30)"
-    },
-    {
-      "@id": "ptype:93",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "93",
-      "skos:prefLabel": "Research Borrower"
-    },
-    {
-      "@id": "ptype:94",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "94",
-      "skos:prefLabel": "MaRLI NYU"
-    },
-    {
-      "@id": "ptype:95",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "95",
-      "skos:prefLabel": "MaRLI Columbia"
-    },
-    {
-      "@id": "ptype:81",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "81",
-      "skos:prefLabel": "MaRLI (9/30)"
+      "skos:notation": "61",
+      "skos:prefLabel": "Child 0-12 All Access Metro"
     },
     {
       "@id": "ptype:86",
@@ -135,55 +31,11 @@
       "skos:prefLabel": "Wertheim Scholar"
     },
     {
-      "@id": "ptype:87",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "87",
-      "skos:prefLabel": "Allen Scholar"
-    },
-    {
-      "@id": "ptype:84",
+      "@id": "ptype:81",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "84",
-      "skos:prefLabel": "Visitor (3 Month Limited Use)"
-    },
-    {
-      "@id": "ptype:85",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "85",
-      "skos:prefLabel": "ILL - Research"
-    },
-    {
-      "@id": "ptype:88",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "88",
-      "skos:prefLabel": "Shoichi Noma Scholar"
-    },
-    {
-      "@id": "ptype:89",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "89",
-      "skos:prefLabel": "Cullman Scholar"
-    },
-    {
-      "@id": "ptype:108",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "108",
-      "skos:prefLabel": "Partner Card - Princeton"
+      "skos:notation": "81",
+      "skos:prefLabel": "MaRLI (9/30)"
     },
     {
       "@id": "ptype:101",
@@ -191,37 +43,6 @@
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "101",
       "skos:prefLabel": "PENDING DISPUTE"
-    },
-    {
-      "@id": "ptype:106",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "106",
-      "skos:prefLabel": "NYPL Department"
-    },
-    {
-      "@id": "ptype:107",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "107",
-      "skos:prefLabel": "Partner Card - Columbia"
-    },
-    {
-      "@id": "ptype:60",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "60",
-      "skos:prefLabel": "Child 0-12 Juv Only Metro"
-    },
-    {
-      "@id": "ptype:61",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "61",
-      "skos:prefLabel": "Child 0-12 All Access Metro"
     },
     {
       "@id": "ptype:62",
@@ -238,88 +59,14 @@
       "skos:prefLabel": "Child 0-12 All Access NY State"
     },
     {
-      "@id": "ptype:1",
+      "@id": "ptype:78",
       "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "1",
-      "skos:prefLabel": "Web Applicant (No Borrowing)"
-    },
-    {
-      "@id": "ptype:0",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "0",
-      "skos:prefLabel": "Undefined (Do Not Use)"
-    },
-    {
-      "@id": "ptype:3",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "3",
-      "skos:prefLabel": "SimplyE Non-Metro"
-    },
-    {
-      "@id": "ptype:149",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "149",
-      "skos:prefLabel": "MyLibraryNYC Educator Queens"
-    },
-    {
-      "@id": "ptype:116",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "116",
-      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
-    },
-    {
-      "@id": "ptype:91",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "91",
-      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
-    },
-    {
-      "@id": "ptype:90",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "90",
-      "skos:prefLabel": "Organization (1 Year Only)"
-    },
-    {
-      "@id": "ptype:151",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "151",
-      "skos:prefLabel": "MyLibraryNYC Educator"
-    },
-    {
-      "@id": "ptype:150",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "150",
-      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
-    },
-    {
-      "@id": "ptype:153",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "153",
-      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
-    },
-    {
-      "@id": "ptype:152",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "152",
-      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
-    },
-    {
-      "@id": "ptype:2",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "2",
-      "skos:prefLabel": "SimplyE Metro"
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "78",
+      "skos:prefLabel": "Short Term Scholar"
     },
     {
       "@id": "ptype:11",
@@ -329,11 +76,164 @@
       "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
     },
     {
-      "@id": "ptype:10",
+      "@id": "ptype:51",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "10",
-      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+      "skos:notation": "51",
+      "skos:prefLabel": "Teen 13-17 NY State"
+    },
+    {
+      "@id": "ptype:75",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "75",
+      "skos:prefLabel": "Schomburg Scholar"
+    },
+    {
+      "@id": "ptype:88",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "88",
+      "skos:prefLabel": "Shoichi Noma Scholar"
+    },
+    {
+      "@id": "ptype:72",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "72",
+      "skos:prefLabel": "Homebound NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:108",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "108",
+      "skos:prefLabel": "Partner Card - Princeton"
+    },
+    {
+      "@id": "ptype:89",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "89",
+      "skos:prefLabel": "Cullman Scholar"
+    },
+    {
+      "@id": "ptype:87",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "87",
+      "skos:prefLabel": "Allen Scholar"
+    },
+    {
+      "@id": "ptype:152",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "152",
+      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
+    },
+    {
+      "@id": "ptype:93",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "93",
+      "skos:prefLabel": "Research Borrower"
+    },
+    {
+      "@id": "ptype:91",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "91",
+      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
+    },
+    {
+      "@id": "ptype:83",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "83",
+      "skos:prefLabel": "Temporary (3 Day Research Only)"
+    },
+    {
+      "@id": "ptype:100",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "100",
+      "skos:prefLabel": "INACTIVE PATRON"
+    },
+    {
+      "@id": "ptype:50",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "50",
+      "skos:prefLabel": "Teen 13-17 Metro"
+    },
+    {
+      "@id": "ptype:106",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "106",
+      "skos:prefLabel": "NYPL Department"
+    },
+    {
+      "@id": "ptype:3",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "3",
+      "skos:prefLabel": "SimplyE Non-Metro"
+    },
+    {
+      "@id": "ptype:31",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "31",
+      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
+    },
+    {
+      "@id": "ptype:95",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "95",
+      "skos:prefLabel": "MaRLI Columbia"
+    },
+    {
+      "@id": "ptype:120",
+      "@type": "nypl:PatronType",
+      "skos:notation": "120",
+      "skos:prefLabel": "Easy Borrowing AdultPilot"
+    },
+    {
+      "@id": "ptype:84",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "84",
+      "skos:prefLabel": "Visitor (3 Month Limited Use)"
+    },
+    {
+      "@id": "ptype:149",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "149",
+      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+    },
+    {
+      "@id": "ptype:121",
+      "@type": "nypl:PatronType",
+      "skos:notation": "121",
+      "skos:prefLabel": "Easy Borrowing SeniorPilot"
     },
     {
       "@id": "ptype:76",
@@ -346,18 +246,126 @@
       "skos:prefLabel": "SASB Scholar RM 217"
     },
     {
-      "@id": "ptype:120",
+      "@id": "ptype:0",
       "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [],
-      "skos:notation": "120",
-      "skos:prefLabel": "Easy Borrowing AdultPilot"
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "0",
+      "skos:prefLabel": "Undefined (Do Not Use)"
     },
     {
-      "@id": "ptype:121",
+      "@id": "ptype:1",
       "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [],
-      "skos:notation": "121",
-      "skos:prefLabel": "Easy Borrowing SeniorPilot"
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "1",
+      "skos:prefLabel": "Web Applicant (No Borrowing)"
+    },
+    {
+      "@id": "ptype:151",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "151",
+      "skos:prefLabel": "MyLibraryNYC Educator"
+    },
+    {
+      "@id": "ptype:70",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "70",
+      "skos:prefLabel": "Disabled Metro NY (3 Year)"
+    },
+    {
+      "@id": "ptype:90",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "90",
+      "skos:prefLabel": "Organization (1 Year Only)"
+    },
+    {
+      "@id": "ptype:60",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "60",
+      "skos:prefLabel": "Child 0-12 Juv Only Metro"
+    },
+    {
+      "@id": "ptype:82",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "82",
+      "skos:prefLabel": "Scholar"
+    },
+    {
+      "@id": "ptype:30",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "30",
+      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:2",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "2",
+      "skos:prefLabel": "SimplyE Metro"
+    },
+    {
+      "@id": "ptype:153",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "153",
+      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
+    },
+    {
+      "@id": "ptype:73",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "73",
+      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:150",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "150",
+      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
+    },
+    {
+      "@id": "ptype:94",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "94",
+      "skos:prefLabel": "MaRLI NYU"
+    },
+    {
+      "@id": "ptype:107",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "107",
+      "skos:prefLabel": "Partner Card - Columbia"
+    },
+    {
+      "@id": "ptype:116",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "116",
+      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+    },
+    {
+      "@id": "ptype:85",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "85",
+      "skos:prefLabel": "ILL - Research"
+    },
+    {
+      "@id": "ptype:80",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "80",
+      "skos:prefLabel": "CUNY Graduate Center (9/30)"
     }
   ]
 }


### PR DESCRIPTION
Adds ptype 75 for Schomburg Scholar.

Validation script output:

```
$ python validate-changes.py patronTypes   
Comparing patronTypes in add-ptype-75 to master
Keys Added: 1
Keys Deleted: 0
Keys Altered: 2

ALTERED KEY: 120

ALTERED KEY: 121
```

The changes to ptype 120 and 121 appear to be that previously those ptypes had ` "nypl:deliveryLocationAccess": [],` and they now have no `nypl:deliveryLocationAccess` property at all. Those are both valid serializations for the entity having no `deliveryLocationAccess` statements. 

I believe the two places this property is used are:
 - https://github.com/NYPL/discovery-api/blob/0efe0a2cb5d009655197ef9c412e157f034bb123/lib/delivery-locations-resolver.js#L152
  - https://github.com/NYPL-discovery/patron-eligibility-service/blob/3133ddb80a371ab07f6fd239a28556e64157c1b2/checkEligibility.js#L122

In both cases, the code treats `undefined` and `[]` as equivalent values.

This is NYPL-Core version v1.41 (this PR is tagged v1.41a)