### PR TITLE
Noref contributor mappings fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### v1.55
+ - Ensure all entries in field-mapping-bib that have "parallel" field
+   counterparts are configured either with explicit `subfields` or
+   `excludedSubfields`
+
 ### v1.54
  - Reconfigure how parallels are related in field-mapping-bib using isParallelFor
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.54
+v1.55
 
 ## Contributing
 

--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -104,13 +104,16 @@
         "subfields": [ "a", "b", "c", "q", "d", "j" ]
       },
       {
-        "marc": "710"
+        "marc": "710",
+        "excludedSubfields": [ "0", "6" ]
       },
       {
-        "marc": "711"
+        "marc": "711",
+        "excludedSubfields": [ "0", "6" ]
       },
       {
-        "marc": "720"
+        "marc": "720",
+        "excludedSubfields": [ "0", "6" ]
       },
       {
         "marc": "791",

--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -145,10 +145,12 @@
         "subfields": [ "a", "b", "c", "q", "d", "j" ]
       },
       {
-        "marc": "110"
+        "marc": "110",
+        "excludedSubfields": [ "0", "6" ]
       },
       {
-        "marc": "111"
+        "marc": "111",
+        "excludedSubfields": [ "0", "6" ]
       }
     ]
   },
@@ -249,7 +251,8 @@
     "jsonLdKey": "editionStatement",
     "paths": [
       {
-        "marc": "250"
+        "marc": "250",
+        "excludedSubfields": [ "0", "6" ]
       }
     ]
   },


### PR DESCRIPTION
This addresses an issue extracting parallel values for mappings that were previously defined without explicit subfields. In general, where possible, we want to define our mappings explicitly in terms of the subfields to include - or alternatively what subfields to exclude. This update adds `excludedSubfields` to several mappings that previously weren't explicit about subfields. This contributed to an issue in the discovery-store-poster where the "parallel" counterparts for those mappings were coming up empty.

This supports [a fix in discovery-store-poster around parallel field extraction](https://github.com/NYPL-discovery/discovery-store-poster/pull/133)

This is tagged `v1.55a`