### PR TITLE
Noref fix publisher parallel literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### v1.56
+ - Rename parallelPublisher to parallelPublisherLiteral in field-mapping-bib to
+   match convention.
+
 ### v1.55
  - Ensure all entries in field-mapping-bib that have "parallel" field
    counterparts are configured either with explicit `subfields` or

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.55
+v1.56
 
 ## Contributing
 

--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -814,8 +814,8 @@
     "isParallelFor": "Series statement"
   },
   "Parallel Publisher": {
-    "pred": "nypl:parallelPublisher",
-    "jsonLdKey": "parallelPublisher",
+    "pred": "nypl:parallelPublisherLiteral",
+    "jsonLdKey": "parallelPublisherLiteral",
     "isParallelFor": "Publisher literal"
   },
   "Parallel Publication Statement": {


### PR DESCRIPTION
### v1.56
 - Rename parallelPublisher to parallelPublisherLiteral in field-mapping-bib to
   match convention.

This is tagged `v1.56a`