### PR TITLE
Scc 3132 Update PF customer code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### v1.61
+- add missing customer codes from spreadsheet to customer code PF
+
 ### v1.60
 - add volume raw, volume range, format, type, date raw, and date range properties to item field mapping 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # CHANGELOG
 
+### v1.62
+ - replace PF customer codes with new spreadsheet values
+
 ### v1.61
-- add missing customer codes from spreadsheet to customer code PF
+ - add missing customer codes from spreadsheet to customer code PF
 
 ### v1.60
-- add volume raw, volume range, format, type, date raw, and date range properties to item field mapping 
+ - add volume raw, volume range, format, type, date raw, and date range properties to item field mapping 
 
 ### v1.56
  - Rename parallelPublisher to parallelPublisherLiteral in field-mapping-bib to

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.60
+v1.61
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.61
+v1.62
 
 ## Contributing
 

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -98,8 +98,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OD,
-true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OD,true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -98,7 +98,8 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NB;NC;ND;NE;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OA;OC;ON;OW,true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OD,
+true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -98,7 +98,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NB;NP;SR,true,0003
+PF,PF,"Firestone Library, Microforms",NB;NC;ND;NE;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OA;OC;ON;OW,true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,20 +7,7 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CA",
-      "skos:prefLabel": "Science & Engineering Lib (NWC)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -29,62 +16,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HK",
-      "skos:prefLabel": "KSG LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -93,11 +29,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -106,79 +42,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CP",
-      "skos:prefLabel": "CP"
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -187,24 +55,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -254,37 +109,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "HR",
-      "skos:prefLabel": "HSL Restricted"
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OZ",
-      "skos:prefLabel": "SASB no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -293,11 +122,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -306,11 +148,37 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -319,8 +187,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CV",
@@ -336,6 +220,19 @@
       "skos:prefLabel": "Butler Media Collection"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/PB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -347,6 +244,318 @@
       },
       "skos:notation": "PB",
       "skos:prefLabel": "Firestone Library Use Only"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HY",
+      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CD",
+      "skos:prefLabel": "CD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PT",
+      "skos:prefLabel": "Engineering Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NR",
+      "skos:prefLabel": "SASB Rare Book Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PA",
@@ -403,6 +612,1315 @@
       "skos:prefLabel": "Firestone LIbrary"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HR",
+      "skos:prefLabel": "HSL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JO",
+      "skos:prefLabel": "JSTOR Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AR",
+      "skos:prefLabel": "Avery Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MCZ",
+      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MP",
+      "skos:prefLabel": "Monographic Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NI",
+      "skos:prefLabel": "LSC Special Formats Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CF",
+      "skos:prefLabel": "Cold Storage Film"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ND",
+      "skos:prefLabel": "SASB Map Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QV",
+      "skos:prefLabel": "Video Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CP",
+      "skos:prefLabel": "CP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NW",
+      "skos:prefLabel": "Donnell Children's Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HK",
+      "skos:prefLabel": "KSG LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GN",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "FL",
+      "skos:prefLabel": "FINE ARTS LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AD",
+      "skos:prefLabel": "Avery Drawings & Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "RR",
+      "skos:prefLabel": "ReCAP Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/JS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
@@ -455,6 +1973,564 @@
       },
       "skos:notation": "JS",
       "skos:prefLabel": "SIBL De-duping candidates"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HV",
+      "skos:prefLabel": "Harvard ReCAP Items"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QL",
+      "skos:prefLabel": "East Asian Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GC",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CA",
+      "skos:prefLabel": "Science & Engineering Lib (NWC)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "TZ",
+      "skos:prefLabel": "TOZZER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PL",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NB",
+      "skos:prefLabel": "SIBL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
@@ -521,7 +2597,7 @@
       "skos:prefLabel": "Lewis Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -530,8 +2606,115 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JQ",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/EV",
@@ -588,7 +2771,52 @@
       "skos:prefLabel": "East Asian Vernacular"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -597,24 +2825,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -623,15 +2838,143 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MZ",
+      "skos:prefLabel": "ReCAP Coordinator"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CU",
+      "skos:prefLabel": "CU Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
@@ -639,8 +2982,172 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "FL",
-      "skos:prefLabel": "FINE ARTS LIBRARY"
+      "skos:notation": "HSdupe",
+      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OZ",
+      "skos:prefLabel": "SASB no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NP",
+      "skos:prefLabel": "LPA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BL",
+      "skos:prefLabel": "Barnard Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NA",
@@ -697,84 +3204,7 @@
       "skos:prefLabel": "NA"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HSdupe",
-      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CF",
-      "skos:prefLabel": "Cold Storage Film"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -783,11 +3213,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -796,24 +3226,21 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PF",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NC"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NE"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NE"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NG"
@@ -876,16 +3303,7 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
         }
       ],
       "nypl:eddRequestable": {
@@ -899,404 +3317,6 @@
       "skos:prefLabel": "Firestone Library, Microforms"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MP",
-      "skos:prefLabel": "Monographic Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MCZ",
-      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PT",
-      "skos:prefLabel": "Engineering Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QV",
-      "skos:prefLabel": "Video Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
       "@id": "http://data.nypl.org/recapCustomerCodes/NX",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -1308,952 +3328,6 @@
       },
       "skos:notation": "NX",
       "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NB",
-      "skos:prefLabel": "SIBL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QL",
-      "skos:prefLabel": "East Asian Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NR",
-      "skos:prefLabel": "SASB Rare Book Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NW",
-      "skos:prefLabel": "Donnell Children's Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CU",
-      "skos:prefLabel": "CU Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BL",
-      "skos:prefLabel": "Barnard Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NI",
-      "skos:prefLabel": "LSC Special Formats Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GN",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JO",
-      "skos:prefLabel": "JSTOR Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HW",
@@ -2307,100 +3381,7 @@
       "skos:prefLabel": "WIDENER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JQ",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PL",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2409,1001 +3390,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HV",
-      "skos:prefLabel": "Harvard ReCAP Items"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ND",
-      "skos:prefLabel": "SASB Map Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AD",
-      "skos:prefLabel": "Avery Drawings & Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NP",
-      "skos:prefLabel": "LPA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GC",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CD",
-      "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "RR",
-      "skos:prefLabel": "ReCAP Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HY",
-      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MZ",
-      "skos:prefLabel": "ReCAP Coordinator"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AR",
-      "skos:prefLabel": "Avery Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "TZ",
-      "skos:prefLabel": "TOZZER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
     }
   ]
 }

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,888 +7,6 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NI",
-      "skos:prefLabel": "LSC Special Formats Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "TZ",
-      "skos:prefLabel": "TOZZER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NR",
-      "skos:prefLabel": "SASB Rare Book Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "GUT",
-      "skos:prefLabel": "GUTMAN LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NW",
-      "skos:prefLabel": "Donnell Children's Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NX",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CF",
-      "skos:prefLabel": "Cold Storage Film"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PF",
-      "skos:prefLabel": "Firestone Library, Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GN",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
       "@id": "http://data.nypl.org/recapCustomerCodes/CA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -902,33 +20,7 @@
       "skos:prefLabel": "Science & Engineering Lib (NWC)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "RR",
-      "skos:prefLabel": "ReCAP Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -937,1550 +29,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CU",
-      "skos:prefLabel": "CU Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NP",
-      "skos:prefLabel": "LPA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "FL",
-      "skos:prefLabel": "FINE ARTS LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HW",
-      "skos:prefLabel": "WIDENER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NA",
-      "skos:prefLabel": "NA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MP",
-      "skos:prefLabel": "Monographic Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JS",
-      "skos:prefLabel": "SIBL De-duping candidates"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MZ",
-      "skos:prefLabel": "ReCAP Coordinator"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CP",
-      "skos:prefLabel": "CP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QL",
-      "skos:prefLabel": "East Asian Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PB",
-      "skos:prefLabel": "Firestone Library Use Only"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HV",
-      "skos:prefLabel": "Harvard ReCAP Items"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GC",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PT",
-      "skos:prefLabel": "Engineering Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CV",
-      "skos:prefLabel": "Butler Media Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PN",
-      "skos:prefLabel": "Lewis Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CD",
-      "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JO",
-      "skos:prefLabel": "JSTOR Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JQ",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QV",
-      "skos:prefLabel": "Video Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NB",
-      "skos:prefLabel": "SIBL"
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HK",
@@ -2534,36 +84,7 @@
       "skos:prefLabel": "KSG LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ND",
-      "skos:prefLabel": "SASB Map Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2572,11 +93,66 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CP",
+      "skos:prefLabel": "CP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2585,8 +161,47 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HR",
@@ -2643,6 +258,19 @@
       "skos:prefLabel": "HSL Restricted"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -2656,7 +284,33 @@
       "skos:prefLabel": "SASB no Sierra holds"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2665,8 +319,34 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CV",
+      "skos:prefLabel": "Butler Media Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PB",
+      "skos:prefLabel": "Firestone Library Use Only"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PA",
@@ -2723,33 +403,61 @@
       "skos:prefLabel": "Firestone LIbrary"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
       "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "false"
+        "@value": "true"
       },
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
+      "skos:notation": "JS",
+      "skos:prefLabel": "SIBL De-duping candidates"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -2796,65 +504,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HSdupe",
-      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
+      "skos:notation": "GUT",
+      "skos:prefLabel": "GUTMAN LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
+      "skos:notation": "PN",
+      "skos:prefLabel": "Lewis Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2863,251 +530,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AR",
-      "skos:prefLabel": "Avery Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PL",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/EV",
@@ -3177,20 +601,20 @@
       "skos:prefLabel": "JL"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "AD",
-      "skos:prefLabel": "Avery Drawings & Archives"
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3199,8 +623,373 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "FL",
+      "skos:prefLabel": "FINE ARTS LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NA",
+      "skos:prefLabel": "NA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HSdupe",
+      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CF",
+      "skos:prefLabel": "Cold Storage Film"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PF",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NI"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NK"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NN"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NS"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NT"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NV"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NX"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NY"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NZ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PF",
+      "skos:prefLabel": "Firestone Library, Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MP",
+      "skos:prefLabel": "Monographic Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
@@ -3254,6 +1043,2029 @@
       "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PT",
+      "skos:prefLabel": "Engineering Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QV",
+      "skos:prefLabel": "Video Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NX",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NB",
+      "skos:prefLabel": "SIBL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QL",
+      "skos:prefLabel": "East Asian Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NR",
+      "skos:prefLabel": "SASB Rare Book Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NW",
+      "skos:prefLabel": "Donnell Children's Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CU",
+      "skos:prefLabel": "CU Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BL",
+      "skos:prefLabel": "Barnard Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NI",
+      "skos:prefLabel": "LSC Special Formats Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GN",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JO",
+      "skos:prefLabel": "JSTOR Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HW",
+      "skos:prefLabel": "WIDENER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JQ",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PL",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HV",
+      "skos:prefLabel": "Harvard ReCAP Items"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ND",
+      "skos:prefLabel": "SASB Map Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AD",
+      "skos:prefLabel": "Avery Drawings & Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NP",
+      "skos:prefLabel": "LPA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GC",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CD",
+      "skos:prefLabel": "CD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "RR",
+      "skos:prefLabel": "ReCAP Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/HY",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
@@ -3305,7 +3117,7 @@
       "skos:prefLabel": "HARVARD YENCHING LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3314,11 +3126,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
+      "skos:notation": "MZ",
+      "skos:prefLabel": "ReCAP Coordinator"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3327,8 +3139,271 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BL",
-      "skos:prefLabel": "Barnard Library"
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AR",
+      "skos:prefLabel": "Avery Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "TZ",
+      "skos:prefLabel": "TOZZER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
     }
   ]
 }


### PR DESCRIPTION
Update PF deliverable codes with all of the codes in the spreadsheet

validate changes:

```
Comparing recapCustomerCodes in SCC-3132 to master
Keys Added: 0
Keys Deleted: 0
Keys Altered: 1

ALTERED KEY: PF
Attribute(Pos): root['nypl:deliverableTo'][1]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NC'}
Attribute(Pos): root['nypl:deliverableTo'][2]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/ND'}
Attribute(Pos): root['nypl:deliverableTo'][3]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NE'}
Attribute(Pos): root['nypl:deliverableTo'][4]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NG'}
Attribute(Pos): root['nypl:deliverableTo'][5]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NH'}
Attribute(Pos): root['nypl:deliverableTo'][6]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NI'}
Attribute(Pos): root['nypl:deliverableTo'][7]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NJ'}
Attribute(Pos): root['nypl:deliverableTo'][8]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NK'}
Attribute(Pos): root['nypl:deliverableTo'][9]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NM'}
Attribute(Pos): root['nypl:deliverableTo'][10]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NN'}
Attribute(Pos): root['nypl:deliverableTo'][11]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NO'}
Attribute(Pos): root['nypl:deliverableTo'][13]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NR'}
Attribute(Pos): root['nypl:deliverableTo'][14]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NS'}
Attribute(Pos): root['nypl:deliverableTo'][15]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NT'}
Attribute(Pos): root['nypl:deliverableTo'][16]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NV'}
Attribute(Pos): root['nypl:deliverableTo'][17]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NX'}
Attribute(Pos): root['nypl:deliverableTo'][18]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NY'}
Attribute(Pos): root['nypl:deliverableTo'][19]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/NZ'}
Attribute(Pos): root['nypl:deliverableTo'][20]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/SA'}
Attribute(Pos): root['nypl:deliverableTo'][21]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/SM'}
Attribute(Pos): root['nypl:deliverableTo'][22]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/SP'}
Attribute(Pos): root['nypl:deliverableTo'][24]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OA'}
Attribute(Pos): root['nypl:deliverableTo'][25]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OC'}
Attribute(Pos): root['nypl:deliverableTo'][26]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/ON'}
Attribute(Pos): root['nypl:deliverableTo'][27]
Added Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OW'}

```