### PR TITLE
SCC 3248: Index marc 001 as OCLC number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### v1.66
+ - Add new bib field mapping for OCLC numbers in marc 001
+
 ### v1.65
  - Add item.dueDate to field mapping
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v1.65
+v1.66
 
 ## Contributing
 

--- a/mappings/recap-discovery/field-mapping-bib.json
+++ b/mappings/recap-discovery/field-mapping-bib.json
@@ -813,6 +813,9 @@
         "marc": "035",
         "subfields": [ "a" ],
         "notes": "Reject if not prefixed '(OCoLC)'"
+      },
+      {
+        "marc": "001"
       }
     ]
   },


### PR DESCRIPTION
Add new field mapping for oclc numbers in marc 001

This is tagged `v1.66a`

https://jira.nypl.org/browse/SCC-3248