### PR TITLE
remove trailing space

### DIFF
--- a/vocabularies/csv/statuses.csv
+++ b/vocabularies/csv/statuses.csv
@@ -1,5 +1,5 @@
 id,skos:notation,skos:prefLabel,skos:altLabel,nypl:requestable,skos:note
-a,-,Available ,AVAILABLE,true,"for Sierra code ""-"", if hold present or if due date present, then requestable=false"
+a,-,Available,AVAILABLE,true,"for Sierra code ""-"", if hold present or if due date present, then requestable=false"
 oh,!,On Holdshelf,ON HOLDSHELF,true,
 mt,?,Missing in transit,MISSING IN TRANSIT,false,
 il,%,ILL returned,ILL RETURNED,false,

--- a/vocabularies/json-ld/statuses.json
+++ b/vocabularies/json-ld/statuses.json
@@ -6,37 +6,26 @@
   },
   "@graph": [
     {
-      "@id": "nyplStatus:w",
+      "@id": "nyplStatus:s",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Withdrawn",
-      "skos:notation": "w",
-      "skos:prefLabel": "Withdrawn"
+      "skos:altLabel": "Staff use",
+      "skos:notation": "~",
+      "skos:prefLabel": "Staff use"
     },
     {
-      "@id": "nyplStatus:d",
+      "@id": "nyplStatus:l",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Damaged",
-      "skos:notation": "d",
-      "skos:prefLabel": "Damaged"
-    },
-    {
-      "@id": "nyplStatus:n",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "BILLED",
-      "skos:notation": "n",
-      "skos:prefLabel": "Billed "
+      "skos:altLabel": "Lost in inventory",
+      "skos:notation": "l",
+      "skos:prefLabel": "Lost in inventory"
     },
     {
       "@id": "nyplStatus:p",
@@ -61,27 +50,15 @@
       "skos:prefLabel": "Missing"
     },
     {
-      "@id": "nyplStatus:i",
+      "@id": "nyplStatus:b",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "At bindery",
-      "skos:notation": "i",
-      "skos:prefLabel": "At bindery"
-    },
-    {
-      "@id": "nyplStatus:a",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:altLabel": "AVAILABLE",
-      "skos:notation": "-",
-      "skos:note": "for Sierra code \"-\", if hold present or if due date present, then requestable=false",
-      "skos:prefLabel": "Available "
+      "skos:altLabel": "New-in process",
+      "skos:notation": "b",
+      "skos:prefLabel": "New-in process"
     },
     {
       "@id": "nyplStatus:lp",
@@ -95,6 +72,50 @@
       "skos:prefLabel": "Lost and paid"
     },
     {
+      "@id": "nyplStatus:c",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Closed branch",
+      "skos:notation": "c",
+      "skos:prefLabel": "Closed branch"
+    },
+    {
+      "@id": "nyplStatus:mt",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "MISSING IN TRANSIT",
+      "skos:notation": "?",
+      "skos:prefLabel": "Missing in transit"
+    },
+    {
+      "@id": "nyplStatus:r",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Loaned (ReCAP)",
+      "skos:notation": "r",
+      "skos:prefLabel": "Loaned (ReCAP)"
+    },
+    {
+      "@id": "nyplStatus:t",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:altLabel": "IN TRANSIT",
+      "skos:notation": "t",
+      "skos:prefLabel": "In transit"
+    },
+    {
       "@id": "nyplStatus:e",
       "@type": "nypl:Status",
       "nypl:requestable": {
@@ -106,55 +127,59 @@
       "skos:prefLabel": "On exhibit"
     },
     {
-      "@id": "nyplStatus:oh",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:altLabel": "ON HOLDSHELF",
-      "skos:notation": "!",
-      "skos:prefLabel": "On Holdshelf"
-    },
-    {
-      "@id": "nyplStatus:l",
+      "@id": "nyplStatus:h",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Lost in inventory",
-      "skos:notation": "l",
-      "skos:prefLabel": "Lost in inventory"
+      "skos:altLabel": "Phone request",
+      "skos:notation": "h",
+      "skos:prefLabel": "Phone request"
     },
     {
-      "@id": "nyplStatus:g",
+      "@id": "nyplStatus:u",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Storage",
-      "skos:notation": "g",
-      "skos:prefLabel": "Storage"
+      "skos:altLabel": "Temporarily unavailable",
+      "skos:notation": "u",
+      "skos:prefLabel": "Temporarily unavailable"
     },
     {
-      "@id": "nyplStatus:x",
-      "@type": "nypl:Status",
-      "skos:altLabel": "MML REQUEST",
-      "skos:notation": "x",
-      "skos:prefLabel": "Mid-Manhattan request"
-    },
-    {
-      "@id": "nyplStatus:s",
+      "@id": "nyplStatus:d",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Staff use",
-      "skos:notation": "~",
-      "skos:prefLabel": "Staff use"
+      "skos:altLabel": "Damaged",
+      "skos:notation": "d",
+      "skos:prefLabel": "Damaged"
+    },
+    {
+      "@id": "nyplStatus:na",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Not available",
+      "skos:notation": "na",
+      "skos:prefLabel": "Not available"
+    },
+    {
+      "@id": "nyplStatus:j",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Overflow",
+      "skos:notation": "j",
+      "skos:prefLabel": "Overflow"
     },
     {
       "@id": "nyplStatus:su",
@@ -169,37 +194,104 @@
       "skos:prefLabel": "Supervised use"
     },
     {
-      "@id": "nyplStatus:c",
+      "@id": "nyplStatus:f",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Closed branch",
-      "skos:notation": "c",
-      "skos:prefLabel": "Closed branch"
+      "skos:altLabel": "Being filmed",
+      "skos:notation": "f",
+      "skos:prefLabel": "Being filmed"
     },
     {
-      "@id": "nyplStatus:b",
+      "@id": "nyplStatus:n",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "New-in process",
-      "skos:notation": "b",
-      "skos:prefLabel": "New-in process"
+      "skos:altLabel": "BILLED",
+      "skos:notation": "n",
+      "skos:prefLabel": "Billed "
     },
     {
-      "@id": "nyplStatus:na",
+      "@id": "nyplStatus:i",
       "@type": "nypl:Status",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Not available",
-      "skos:notation": "na",
-      "skos:prefLabel": "Not available"
+      "skos:altLabel": "At bindery",
+      "skos:notation": "i",
+      "skos:prefLabel": "At bindery"
+    },
+    {
+      "@id": "nyplStatus:oh",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:altLabel": "ON HOLDSHELF",
+      "skos:notation": "!",
+      "skos:prefLabel": "On Holdshelf"
+    },
+    {
+      "@id": "nyplStatus:z",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "DISPUTED ITEM",
+      "skos:notation": "z",
+      "skos:prefLabel": "Disputed Item"
+    },
+    {
+      "@id": "nyplStatus:a",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:altLabel": "AVAILABLE",
+      "skos:notation": "-",
+      "skos:note": "for Sierra code \"-\", if hold present or if due date present, then requestable=false",
+      "skos:prefLabel": "Available"
+    },
+    {
+      "@id": "nyplStatus:g",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Storage",
+      "skos:notation": "g",
+      "skos:prefLabel": "Storage"
+    },
+    {
+      "@id": "nyplStatus:v",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Preservation",
+      "skos:notation": "v",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "nyplStatus:w",
+      "@type": "nypl:Status",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Withdrawn",
+      "skos:notation": "w",
+      "skos:prefLabel": "Withdrawn"
     },
     {
       "@id": "nyplStatus:il",
@@ -213,26 +305,11 @@
       "skos:prefLabel": "ILL returned"
     },
     {
-      "@id": "nyplStatus:u",
+      "@id": "nyplStatus:x",
       "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Temporarily unavailable",
-      "skos:notation": "u",
-      "skos:prefLabel": "Temporarily unavailable"
-    },
-    {
-      "@id": "nyplStatus:j",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Overflow",
-      "skos:notation": "j",
-      "skos:prefLabel": "Overflow"
+      "skos:altLabel": "MML REQUEST",
+      "skos:notation": "x",
+      "skos:prefLabel": "Mid-Manhattan request"
     },
     {
       "@id": "nyplStatus:k",
@@ -244,28 +321,6 @@
       "skos:altLabel": "Check with staff",
       "skos:notation": "k",
       "skos:prefLabel": "Check with staff"
-    },
-    {
-      "@id": "nyplStatus:t",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:altLabel": "IN TRANSIT",
-      "skos:notation": "t",
-      "skos:prefLabel": "In transit"
-    },
-    {
-      "@id": "nyplStatus:h",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Phone request",
-      "skos:notation": "h",
-      "skos:prefLabel": "Phone request"
     },
     {
       "@id": "nyplStatus:co",
@@ -280,17 +335,6 @@
       "skos:prefLabel": "Loaned"
     },
     {
-      "@id": "nyplStatus:r",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Loaned (ReCAP)",
-      "skos:notation": "r",
-      "skos:prefLabel": "Loaned (ReCAP)"
-    },
-    {
       "@id": "nyplStatus:o",
       "@type": "nypl:Status",
       "nypl:requestable": {
@@ -301,50 +345,6 @@
       "skos:notation": "o",
       "skos:note": "updated 20171001",
       "skos:prefLabel": "Use in library"
-    },
-    {
-      "@id": "nyplStatus:v",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Preservation",
-      "skos:notation": "v",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "nyplStatus:mt",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "MISSING IN TRANSIT",
-      "skos:notation": "?",
-      "skos:prefLabel": "Missing in transit"
-    },
-    {
-      "@id": "nyplStatus:z",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "DISPUTED ITEM",
-      "skos:notation": "z",
-      "skos:prefLabel": "Disputed Item"
-    },
-    {
-      "@id": "nyplStatus:f",
-      "@type": "nypl:Status",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Being filmed",
-      "skos:notation": "f",
-      "skos:prefLabel": "Being filmed"
     }
   ]
 }


### PR DESCRIPTION
This is an attempt to fix the bug in DFE where available is appearing twice in the status filter. I'm not entirely sure if this is the issue, but it looks like there are 2 item status aggregations returning for some bibs, one for label `"status:a||Available"` and one for `"status:a||Available "` (with a trailing space). I'm updating the status csv and json to remove that space. The validate changes script is not picking up the change, but I've visually verified that it has updated and that the other statuses look copacetic.