### PR TITLE
Scc 3748

### DIFF
--- a/vocabularies/csv/m2CustomerCodes.csv
+++ b/vocabularies/csv/m2CustomerCodes.csv
@@ -12,8 +12,8 @@ XA,General Research,AR;AA;AJ;AL;AM;AC;AW;AE;AN,true,deliver to any NYPL RL,,"Con
 XF,,AR;AA;AJ;AL;AM;AC;AW;AE;AN,true,deliver to any NYPL RL,,?
 XG,ART,AR;AA;AJ;AL;AM;AC;AW;AE;AN,true,ART Collection deliver to any NYPL RL,,Contains: Art & Architecture
 XH,JWS,AR;AA;AJ;AL;AM;AC;AW;AE;AN,true,JWS Collection deliver to any NYPL RL,,Contains: Jewish (Dorot) Collection
-XP,MAP,AM,FALSE,MAP Collection delivery to rm 121 & 117 only,,Contains: Map
-XS,Photography Collection,AA,FALSE,Photography Collection deliver to rm 300 only,,Contains: Photography
+XP,MAP,AM,TRUE,MAP Collection delivery to rm 121 & 117 only,,Contains: Map
+XS,Photography Collection,AA,TRUE,Photography Collection deliver to rm 300 only,,Contains: Photography
 JS,SIBL Serials,AR;AA;AJ;AL;AM;AC;AW;AE;AN,true,SIBL Serials deliver to any NYPL RL,,Contains: SIBL Serials
 EM,EDD,,,,,"Presumably associated with maedd, which is not requestable, so there's no functional point linking it"
 AR,GRD - room 315,,,,mal,

--- a/vocabularies/json-ld/m2CustomerCodes.json
+++ b/vocabularies/json-ld/m2CustomerCodes.json
@@ -7,7 +7,7 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/XA",
+      "@id": "http://data.nypl.org/m2CustomerCodes/XF",
       "@type": "nypl:m2CustomerCode",
       "nypl:deliverableTo": [
         {
@@ -42,47 +42,8 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "skos:notation": "XA",
-      "skos:prefLabel": "General Research"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/JS",
-      "@type": "nypl:m2CustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
-        }
-      ],
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:notation": "JS",
-      "skos:prefLabel": "SIBL Serials"
+      "skos:notation": "XF",
+      "skos:prefLabel": ""
     },
     {
       "@id": "http://data.nypl.org/m2CustomerCodes/AM",
@@ -91,10 +52,16 @@
       "skos:prefLabel": "MAP - room 117"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AW",
+      "@id": "http://data.nypl.org/m2CustomerCodes/IL",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AW",
-      "skos:prefLabel": "Wertheim Study"
+      "skos:notation": "IL",
+      "skos:prefLabel": "Interlibrary & Document Services"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AN",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AN",
+      "skos:prefLabel": "Noma Schiochi"
     },
     {
       "@id": "http://data.nypl.org/m2CustomerCodes/NQ",
@@ -136,19 +103,7 @@
       "skos:prefLabel": "General Research"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AR",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AR",
-      "skos:prefLabel": "GRD - room 315"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AS",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AS",
-      "skos:prefLabel": "room 217 Scholar Hallway"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/NH",
+      "@id": "http://data.nypl.org/m2CustomerCodes/XA",
       "@type": "nypl:m2CustomerCode",
       "nypl:deliverableTo": [
         {
@@ -183,129 +138,20 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "skos:notation": "NH",
+      "skos:notation": "XA",
       "skos:prefLabel": "General Research"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/XG",
+      "@id": "http://data.nypl.org/m2CustomerCodes/AE",
       "@type": "nypl:m2CustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
-        }
-      ],
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:notation": "XG",
-      "skos:prefLabel": "ART"
+      "skos:notation": "AE",
+      "skos:prefLabel": "Allen Room"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/EM",
+      "@id": "http://data.nypl.org/m2CustomerCodes/AW",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "EM",
-      "skos:prefLabel": "EDD"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AL",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AL",
-      "skos:prefLabel": "LHG - room 121"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AC",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AC",
-      "skos:prefLabel": "Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AA",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AA",
-      "skos:prefLabel": "ART - room 300"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AJ",
-      "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AJ",
-      "skos:prefLabel": "Dorot - room 111"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/XS",
-      "@type": "nypl:m2CustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/m2CustomerCodes/AA"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "FALSE"
-      },
-      "skos:notation": "XS",
-      "skos:prefLabel": "Photography Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/m2CustomerCodes/XF",
-      "@type": "nypl:m2CustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
-        },
-        {
-          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
-        }
-      ],
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:notation": "XF",
-      "skos:prefLabel": ""
+      "skos:notation": "AW",
+      "skos:prefLabel": "Wertheim Study"
     },
     {
       "@id": "http://data.nypl.org/m2CustomerCodes/XH",
@@ -347,10 +193,125 @@
       "skos:prefLabel": "JWS"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/IL",
+      "@id": "http://data.nypl.org/m2CustomerCodes/EM",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "IL",
-      "skos:prefLabel": "Interlibrary & Document Services"
+      "skos:notation": "EM",
+      "skos:prefLabel": "EDD"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/XS",
+      "@type": "nypl:m2CustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/m2CustomerCodes/AA"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "TRUE"
+      },
+      "skos:notation": "XS",
+      "skos:prefLabel": "Photography Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AJ",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AJ",
+      "skos:prefLabel": "Dorot - room 111"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/NH",
+      "@type": "nypl:m2CustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
+        }
+      ],
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "General Research"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AC",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AC",
+      "skos:prefLabel": "Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AR",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AR",
+      "skos:prefLabel": "GRD - room 315"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AG",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AG",
+      "skos:prefLabel": "MaRLi-To-Go"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/JS",
+      "@type": "nypl:m2CustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
+        }
+      ],
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "JS",
+      "skos:prefLabel": "SIBL Serials"
     },
     {
       "@id": "http://data.nypl.org/m2CustomerCodes/XP",
@@ -360,28 +321,67 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "FALSE"
+        "@value": "TRUE"
       },
       "skos:notation": "XP",
       "skos:prefLabel": "MAP"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AG",
+      "@id": "http://data.nypl.org/m2CustomerCodes/AL",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AG",
-      "skos:prefLabel": "MaRLi-To-Go"
+      "skos:notation": "AL",
+      "skos:prefLabel": "LHG - room 121"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AE",
+      "@id": "http://data.nypl.org/m2CustomerCodes/XG",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AE",
-      "skos:prefLabel": "Allen Room"
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AR"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AA"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AJ"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AL"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AM"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AC"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AW"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AE"
+        },
+        {
+          "@id": "http://data.nypl.org/m2CustomerCodes/AN"
+        }
+      ],
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "XG",
+      "skos:prefLabel": "ART"
     },
     {
-      "@id": "http://data.nypl.org/m2CustomerCodes/AN",
+      "@id": "http://data.nypl.org/m2CustomerCodes/AA",
       "@type": "nypl:m2CustomerCode",
-      "skos:notation": "AN",
-      "skos:prefLabel": "Noma Schiochi"
+      "skos:notation": "AA",
+      "skos:prefLabel": "ART - room 300"
+    },
+    {
+      "@id": "http://data.nypl.org/m2CustomerCodes/AS",
+      "@type": "nypl:m2CustomerCode",
+      "skos:notation": "AS",
+      "skos:prefLabel": "room 217 Scholar Hallway"
     }
   ]
 }


### PR DESCRIPTION
Adds nypl:requestable TRUE to XS and XP m2CustomerCodes. 

New changes in SCC-3748:

Comparing m2CustomerCodes in scc-3748 to master
Keys Added: 0
Keys Deleted: 0
Keys Altered: 2

ALTERED KEY: http://data.nypl.org/m2CustomerCodes/XP
  Attribute: root['nypl:requestable']['@value']
  Old Value: FALSE
  New Value: TRUE

ALTERED KEY: http://data.nypl.org/m2CustomerCodes/XS
  Attribute: root['nypl:requestable']['@value']
  Old Value: FALSE
  New Value: TRUE