### PR TITLE
Scc 3952/add scholar delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ### v2.13
- - Add deliverableTo property to patron types 
+ - Add scholarRoom property to patron types 
 
 ### v2.12
  - Make sff3, scff2 requestable 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### v2.13
+ - Add deliverableTo property to patron types 
+
 ### v2.12
  - Make sff3, scff2 requestable 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v2.12
+v2.13
 
 ## Contributing
 

--- a/vocabularies/csv/patronTypes.csv
+++ b/vocabularies/csv/patronTypes.csv
@@ -1,4 +1,4 @@
-skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
+skos:notation,skos:prefLabel,nypl:deliveryLocationAccess,nypl:deliverableTo
 0,Undefined (Do Not Use),Research
 1,Web Applicant (No Borrowing),Research
 2,SimplyE Metro,Research
@@ -17,7 +17,7 @@ skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
 72,Homebound NYC (3 Year),Research
 73,Homebound Juv Only NYC (3 Year),Research
 75,Schomburg Scholar,Research;Scholar
-76,SASB Scholar RM 217,Research;Scholar
+76,SASB Scholar RM 217,Research;Scholar,mal17
 78,Short Term Scholar,Research;Scholar
 80,CUNY Graduate Center (9/30),Research
 81,MaRLI (9/30),Research
@@ -25,10 +25,10 @@ skos:notation,skos:prefLabel,nypl:deliveryLocationAccess
 83,Temporary (3 Day Research Only),Research
 84,Visitor (3 Month Limited Use),Research
 85,ILL - Research,Research
-86,Wertheim Scholar,Research;Scholar
-87,Allen Scholar,Research;Scholar
-88,Shoichi Noma Scholar,Research;Scholar
-89,Cullman Scholar,Research;Scholar
+86,Wertheim Scholar,Research;Scholar,malw
+87,Allen Scholar,Research;Scholar,mala
+88,Shoichi Noma Scholar,Research;Scholar,maln
+89,Cullman Scholar,Research;Scholar,malc
 90,Organization (1 Year Only),Research
 91,(Non-MyLibraryNYC) NYC Educator,Research
 93,Research Borrower,Research

--- a/vocabularies/csv/patronTypes.csv
+++ b/vocabularies/csv/patronTypes.csv
@@ -1,4 +1,4 @@
-skos:notation,skos:prefLabel,nypl:deliveryLocationAccess,nypl:deliverableTo
+skos:notation,skos:prefLabel,nypl:deliveryLocationAccess,nypl:scholarRoom
 0,Undefined (Do Not Use),Research
 1,Web Applicant (No Borrowing),Research
 2,SimplyE Metro,Research

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -7,79 +7,28 @@
   },
   "@graph": [
     {
-      "@id": "ptype:84",
+      "@id": "ptype:82",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "84",
-      "skos:prefLabel": "Visitor (3 Month Limited Use)"
-    },
-    {
-      "@id": "ptype:61",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "61",
-      "skos:prefLabel": "Child 0-12 All Access Metro"
-    },
-    {
-      "@id": "ptype:153",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "153",
-      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
-    },
-    {
-      "@id": "ptype:50",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "50",
-      "skos:prefLabel": "Teen 13-17 Metro"
-    },
-    {
-      "@id": "ptype:80",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "80",
-      "skos:prefLabel": "CUNY Graduate Center (9/30)"
-    },
-    {
-      "@id": "ptype:107",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "107",
-      "skos:prefLabel": "Partner Card - Columbia"
-    },
-    {
-      "@id": "ptype:51",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "51",
-      "skos:prefLabel": "Teen 13-17 NY State"
-    },
-    {
-      "@id": "ptype:86",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "malw",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
       ],
-      "skos:notation": "86",
-      "skos:prefLabel": "Wertheim Scholar"
+      "skos:notation": "82",
+      "skos:prefLabel": "Scholar"
     },
     {
-      "@id": "ptype:108",
+      "@id": "ptype:116",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "108",
-      "skos:prefLabel": "Partner Card - Princeton"
+      "skos:notation": "116",
+      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+    },
+    {
+      "@id": "ptype:91",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "91",
+      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
     },
     {
       "@id": "ptype:89",
@@ -93,52 +42,18 @@
       "skos:prefLabel": "Cullman Scholar"
     },
     {
-      "@id": "ptype:73",
+      "@id": "ptype:10",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "73",
-      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
+      "skos:notation": "10",
+      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
     },
     {
-      "@id": "ptype:2",
+      "@id": "ptype:1",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "2",
-      "skos:prefLabel": "SimplyE Metro"
-    },
-    {
-      "@id": "ptype:11",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "11",
-      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
-    },
-    {
-      "@id": "ptype:31",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "31",
-      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
-    },
-    {
-      "@id": "ptype:94",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "94",
-      "skos:prefLabel": "MaRLI NYU"
-    },
-    {
-      "@id": "ptype:95",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "95",
-      "skos:prefLabel": "MaRLI Columbia"
+      "skos:notation": "1",
+      "skos:prefLabel": "Web Applicant (No Borrowing)"
     },
     {
       "@id": "ptype:87",
@@ -152,144 +67,60 @@
       "skos:prefLabel": "Allen Scholar"
     },
     {
-      "@id": "ptype:121",
+      "@id": "ptype:107",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "skos:notation": "121",
-      "skos:prefLabel": "Easy Borrowing SeniorPilot"
-    },
-    {
-      "@id": "ptype:151",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "151",
-      "skos:prefLabel": "MyLibraryNYC Educator"
+      "skos:notation": "107",
+      "skos:prefLabel": "Partner Card - Columbia"
     },
     {
-      "@id": "ptype:101",
+      "@id": "ptype:63",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "101",
-      "skos:prefLabel": "PENDING DISPUTE"
+      "skos:notation": "63",
+      "skos:prefLabel": "Child 0-12 All Access NY State"
     },
     {
-      "@id": "ptype:85",
+      "@id": "ptype:95",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "85",
-      "skos:prefLabel": "ILL - Research"
-    },
-    {
-      "@id": "ptype:150",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "150",
-      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
-    },
-    {
-      "@id": "ptype:106",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "106",
-      "skos:prefLabel": "NYPL Department"
-    },
-    {
-      "@id": "ptype:76",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "mal17",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "76",
-      "skos:prefLabel": "SASB Scholar RM 217"
-    },
-    {
-      "@id": "ptype:90",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "90",
-      "skos:prefLabel": "Organization (1 Year Only)"
-    },
-    {
-      "@id": "ptype:62",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "62",
-      "skos:prefLabel": "Child 0-12 Juv Only NY State"
-    },
-    {
-      "@id": "ptype:72",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "72",
-      "skos:prefLabel": "Homebound NYC (3 Year)"
-    },
-    {
-      "@id": "ptype:81",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "81",
-      "skos:prefLabel": "MaRLI (9/30)"
-    },
-    {
-      "@id": "ptype:120",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
-      "skos:notation": "120",
-      "skos:prefLabel": "Easy Borrowing AdultPilot"
+      "skos:notation": "95",
+      "skos:prefLabel": "MaRLI Columbia"
     },
     {
       "@id": "ptype:93",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "93",
       "skos:prefLabel": "Research Borrower"
     },
     {
-      "@id": "ptype:10",
+      "@id": "ptype:153",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "10",
-      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+      "skos:notation": "153",
+      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
     },
     {
-      "@id": "ptype:91",
+      "@id": "ptype:152",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "91",
-      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
+      "skos:notation": "152",
+      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
     },
     {
-      "@id": "ptype:1",
+      "@id": "ptype:73",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "1",
-      "skos:prefLabel": "Web Applicant (No Borrowing)"
+      "skos:notation": "73",
+      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
     },
     {
-      "@id": "ptype:63",
+      "@id": "ptype:62",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "63",
-      "skos:prefLabel": "Child 0-12 All Access NY State"
+      "skos:notation": "62",
+      "skos:prefLabel": "Child 0-12 Juv Only NY State"
     },
     {
       "@id": "ptype:88",
@@ -303,41 +134,62 @@
       "skos:prefLabel": "Shoichi Noma Scholar"
     },
     {
-      "@id": "ptype:60",
+      "@id": "ptype:11",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "60",
-      "skos:prefLabel": "Child 0-12 Juv Only Metro"
+      "skos:notation": "11",
+      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
     },
     {
-      "@id": "ptype:3",
+      "@id": "ptype:72",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "3",
-      "skos:prefLabel": "SimplyE Non-Metro"
+      "skos:notation": "72",
+      "skos:prefLabel": "Homebound NYC (3 Year)"
     },
     {
-      "@id": "ptype:149",
+      "@id": "ptype:90",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "149",
-      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+      "skos:notation": "90",
+      "skos:prefLabel": "Organization (1 Year Only)"
     },
     {
-      "@id": "ptype:100",
+      "@id": "ptype:121",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
+      "skos:notation": "121",
+      "skos:prefLabel": "Easy Borrowing SeniorPilot"
+    },
+    {
+      "@id": "ptype:2",
+      "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "100",
-      "skos:prefLabel": "INACTIVE PATRON"
+      "skos:notation": "2",
+      "skos:prefLabel": "SimplyE Metro"
+    },
+    {
+      "@id": "ptype:94",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "94",
+      "skos:prefLabel": "MaRLI NYU"
+    },
+    {
+      "@id": "ptype:85",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "85",
+      "skos:prefLabel": "ILL - Research"
+    },
+    {
+      "@id": "ptype:120",
+      "@type": "nypl:PatronType",
+      "skos:notation": "120",
+      "skos:prefLabel": "Easy Borrowing AdultPilot"
     },
     {
       "@id": "ptype:75",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
@@ -348,7 +200,6 @@
     {
       "@id": "ptype:78",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
@@ -357,63 +208,169 @@
       "skos:prefLabel": "Short Term Scholar"
     },
     {
-      "@id": "ptype:0",
+      "@id": "ptype:151",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "0",
-      "skos:prefLabel": "Undefined (Do Not Use)"
+      "skos:notation": "151",
+      "skos:prefLabel": "MyLibraryNYC Educator"
     },
     {
-      "@id": "ptype:152",
+      "@id": "ptype:51",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "152",
-      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
+      "skos:notation": "51",
+      "skos:prefLabel": "Teen 13-17 NY State"
     },
     {
-      "@id": "ptype:116",
+      "@id": "ptype:31",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "116",
-      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+      "skos:notation": "31",
+      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
     },
     {
-      "@id": "ptype:30",
+      "@id": "ptype:86",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
+      "nypl:deliverableTo": "malw",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "86",
+      "skos:prefLabel": "Wertheim Scholar"
+    },
+    {
+      "@id": "ptype:84",
+      "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "30",
-      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+      "skos:notation": "84",
+      "skos:prefLabel": "Visitor (3 Month Limited Use)"
     },
     {
       "@id": "ptype:83",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "83",
       "skos:prefLabel": "Temporary (3 Day Research Only)"
     },
     {
-      "@id": "ptype:82",
+      "@id": "ptype:76",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
+      "nypl:deliverableTo": "mal17",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
       ],
-      "skos:notation": "82",
-      "skos:prefLabel": "Scholar"
+      "skos:notation": "76",
+      "skos:prefLabel": "SASB Scholar RM 217"
+    },
+    {
+      "@id": "ptype:60",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "60",
+      "skos:prefLabel": "Child 0-12 Juv Only Metro"
+    },
+    {
+      "@id": "ptype:106",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "106",
+      "skos:prefLabel": "NYPL Department"
+    },
+    {
+      "@id": "ptype:61",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "61",
+      "skos:prefLabel": "Child 0-12 All Access Metro"
+    },
+    {
+      "@id": "ptype:100",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "100",
+      "skos:prefLabel": "INACTIVE PATRON"
     },
     {
       "@id": "ptype:70",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "70",
       "skos:prefLabel": "Disabled Metro NY (3 Year)"
+    },
+    {
+      "@id": "ptype:3",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "3",
+      "skos:prefLabel": "SimplyE Non-Metro"
+    },
+    {
+      "@id": "ptype:150",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "150",
+      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
+    },
+    {
+      "@id": "ptype:101",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "101",
+      "skos:prefLabel": "PENDING DISPUTE"
+    },
+    {
+      "@id": "ptype:149",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "149",
+      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+    },
+    {
+      "@id": "ptype:108",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "108",
+      "skos:prefLabel": "Partner Card - Princeton"
+    },
+    {
+      "@id": "ptype:30",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "30",
+      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:50",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "50",
+      "skos:prefLabel": "Teen 13-17 Metro"
+    },
+    {
+      "@id": "ptype:80",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "80",
+      "skos:prefLabel": "CUNY Graduate Center (9/30)"
+    },
+    {
+      "@id": "ptype:0",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "0",
+      "skos:prefLabel": "Undefined (Do Not Use)"
+    },
+    {
+      "@id": "ptype:81",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "81",
+      "skos:prefLabel": "MaRLI (9/30)"
     }
   ]
 }

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -1,11 +1,59 @@
 {
   "@context": {
     "nypl": "http://data.nypl.org/nypl-core/",
+    "nyplLocation": "http://data.nypl.org/locations/",
     "nyplOrg": "http://data.nypl.org/orgs/",
     "ptype": "http://data.nypl.org/patronTypes/",
     "skos": "http://www.w3.org/2004/02/skos/core#"
   },
   "@graph": [
+    {
+      "@id": "ptype:87",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "nypl:scholarRoom": {
+        "@id": "nyplLocation:mala"
+      },
+      "skos:notation": "87",
+      "skos:prefLabel": "Allen Scholar"
+    },
+    {
+      "@id": "ptype:76",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "nypl:scholarRoom": {
+        "@id": "nyplLocation:mal17"
+      },
+      "skos:notation": "76",
+      "skos:prefLabel": "SASB Scholar RM 217"
+    },
+    {
+      "@id": "ptype:94",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "94",
+      "skos:prefLabel": "MaRLI NYU"
+    },
+    {
+      "@id": "ptype:101",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "101",
+      "skos:prefLabel": "PENDING DISPUTE"
+    },
+    {
+      "@id": "ptype:116",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "116",
+      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+    },
     {
       "@id": "ptype:82",
       "@type": "nypl:PatronType",
@@ -17,128 +65,11 @@
       "skos:prefLabel": "Scholar"
     },
     {
-      "@id": "ptype:116",
+      "@id": "ptype:80",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "116",
-      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
-    },
-    {
-      "@id": "ptype:91",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "91",
-      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
-    },
-    {
-      "@id": "ptype:89",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "malc",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "89",
-      "skos:prefLabel": "Cullman Scholar"
-    },
-    {
-      "@id": "ptype:10",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "10",
-      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
-    },
-    {
-      "@id": "ptype:1",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "1",
-      "skos:prefLabel": "Web Applicant (No Borrowing)"
-    },
-    {
-      "@id": "ptype:87",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "mala",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "87",
-      "skos:prefLabel": "Allen Scholar"
-    },
-    {
-      "@id": "ptype:107",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "107",
-      "skos:prefLabel": "Partner Card - Columbia"
-    },
-    {
-      "@id": "ptype:63",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "63",
-      "skos:prefLabel": "Child 0-12 All Access NY State"
-    },
-    {
-      "@id": "ptype:95",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "95",
-      "skos:prefLabel": "MaRLI Columbia"
-    },
-    {
-      "@id": "ptype:93",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "93",
-      "skos:prefLabel": "Research Borrower"
-    },
-    {
-      "@id": "ptype:153",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "153",
-      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
-    },
-    {
-      "@id": "ptype:152",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "152",
-      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
-    },
-    {
-      "@id": "ptype:73",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "73",
-      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
-    },
-    {
-      "@id": "ptype:62",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "62",
-      "skos:prefLabel": "Child 0-12 Juv Only NY State"
-    },
-    {
-      "@id": "ptype:88",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "maln",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "88",
-      "skos:prefLabel": "Shoichi Noma Scholar"
-    },
-    {
-      "@id": "ptype:11",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "11",
-      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
+      "skos:notation": "80",
+      "skos:prefLabel": "CUNY Graduate Center (9/30)"
     },
     {
       "@id": "ptype:72",
@@ -148,31 +79,100 @@
       "skos:prefLabel": "Homebound NYC (3 Year)"
     },
     {
-      "@id": "ptype:90",
+      "@id": "ptype:62",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "90",
-      "skos:prefLabel": "Organization (1 Year Only)"
+      "skos:notation": "62",
+      "skos:prefLabel": "Child 0-12 Juv Only NY State"
     },
     {
-      "@id": "ptype:121",
-      "@type": "nypl:PatronType",
-      "skos:notation": "121",
-      "skos:prefLabel": "Easy Borrowing SeniorPilot"
-    },
-    {
-      "@id": "ptype:2",
+      "@id": "ptype:153",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "2",
-      "skos:prefLabel": "SimplyE Metro"
+      "skos:notation": "153",
+      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
     },
     {
-      "@id": "ptype:94",
+      "@id": "ptype:0",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "94",
-      "skos:prefLabel": "MaRLI NYU"
+      "skos:notation": "0",
+      "skos:prefLabel": "Undefined (Do Not Use)"
+    },
+    {
+      "@id": "ptype:86",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "nypl:scholarRoom": {
+        "@id": "nyplLocation:malw"
+      },
+      "skos:notation": "86",
+      "skos:prefLabel": "Wertheim Scholar"
+    },
+    {
+      "@id": "ptype:1",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "1",
+      "skos:prefLabel": "Web Applicant (No Borrowing)"
+    },
+    {
+      "@id": "ptype:30",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "30",
+      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:10",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "10",
+      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:61",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "61",
+      "skos:prefLabel": "Child 0-12 All Access Metro"
+    },
+    {
+      "@id": "ptype:89",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "nypl:scholarRoom": {
+        "@id": "nyplLocation:malc"
+      },
+      "skos:notation": "89",
+      "skos:prefLabel": "Cullman Scholar"
+    },
+    {
+      "@id": "ptype:108",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "108",
+      "skos:prefLabel": "Partner Card - Princeton"
+    },
+    {
+      "@id": "ptype:149",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "149",
+      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+    },
+    {
+      "@id": "ptype:93",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "93",
+      "skos:prefLabel": "Research Borrower"
     },
     {
       "@id": "ptype:85",
@@ -182,10 +182,18 @@
       "skos:prefLabel": "ILL - Research"
     },
     {
-      "@id": "ptype:120",
+      "@id": "ptype:150",
       "@type": "nypl:PatronType",
-      "skos:notation": "120",
-      "skos:prefLabel": "Easy Borrowing AdultPilot"
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "150",
+      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
+    },
+    {
+      "@id": "ptype:51",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "51",
+      "skos:prefLabel": "Teen 13-17 NY State"
     },
     {
       "@id": "ptype:75",
@@ -198,6 +206,54 @@
       "skos:prefLabel": "Schomburg Scholar"
     },
     {
+      "@id": "ptype:3",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "3",
+      "skos:prefLabel": "SimplyE Non-Metro"
+    },
+    {
+      "@id": "ptype:88",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "nypl:scholarRoom": {
+        "@id": "nyplLocation:maln"
+      },
+      "skos:notation": "88",
+      "skos:prefLabel": "Shoichi Noma Scholar"
+    },
+    {
+      "@id": "ptype:73",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "73",
+      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:83",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "83",
+      "skos:prefLabel": "Temporary (3 Day Research Only)"
+    },
+    {
+      "@id": "ptype:70",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "70",
+      "skos:prefLabel": "Disabled Metro NY (3 Year)"
+    },
+    {
+      "@id": "ptype:100",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "100",
+      "skos:prefLabel": "INACTIVE PATRON"
+    },
+    {
       "@id": "ptype:78",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": [
@@ -208,18 +264,17 @@
       "skos:prefLabel": "Short Term Scholar"
     },
     {
-      "@id": "ptype:151",
+      "@id": "ptype:11",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "151",
-      "skos:prefLabel": "MyLibraryNYC Educator"
+      "skos:notation": "11",
+      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
     },
     {
-      "@id": "ptype:51",
+      "@id": "ptype:120",
       "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "51",
-      "skos:prefLabel": "Teen 13-17 NY State"
+      "skos:notation": "120",
+      "skos:prefLabel": "Easy Borrowing AdultPilot"
     },
     {
       "@id": "ptype:31",
@@ -229,15 +284,73 @@
       "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
     },
     {
-      "@id": "ptype:86",
+      "@id": "ptype:152",
       "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "malw",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "86",
-      "skos:prefLabel": "Wertheim Scholar"
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "152",
+      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
+    },
+    {
+      "@id": "ptype:91",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "91",
+      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
+    },
+    {
+      "@id": "ptype:63",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "63",
+      "skos:prefLabel": "Child 0-12 All Access NY State"
+    },
+    {
+      "@id": "ptype:81",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "81",
+      "skos:prefLabel": "MaRLI (9/30)"
+    },
+    {
+      "@id": "ptype:90",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "90",
+      "skos:prefLabel": "Organization (1 Year Only)"
+    },
+    {
+      "@id": "ptype:151",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "151",
+      "skos:prefLabel": "MyLibraryNYC Educator"
+    },
+    {
+      "@id": "ptype:2",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "2",
+      "skos:prefLabel": "SimplyE Metro"
+    },
+    {
+      "@id": "ptype:50",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "50",
+      "skos:prefLabel": "Teen 13-17 Metro"
+    },
+    {
+      "@id": "ptype:121",
+      "@type": "nypl:PatronType",
+      "skos:notation": "121",
+      "skos:prefLabel": "Easy Borrowing SeniorPilot"
+    },
+    {
+      "@id": "ptype:95",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "95",
+      "skos:prefLabel": "MaRLI Columbia"
     },
     {
       "@id": "ptype:84",
@@ -247,29 +360,18 @@
       "skos:prefLabel": "Visitor (3 Month Limited Use)"
     },
     {
-      "@id": "ptype:83",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "83",
-      "skos:prefLabel": "Temporary (3 Day Research Only)"
-    },
-    {
-      "@id": "ptype:76",
-      "@type": "nypl:PatronType",
-      "nypl:deliverableTo": "mal17",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "76",
-      "skos:prefLabel": "SASB Scholar RM 217"
-    },
-    {
       "@id": "ptype:60",
       "@type": "nypl:PatronType",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "60",
       "skos:prefLabel": "Child 0-12 Juv Only Metro"
+    },
+    {
+      "@id": "ptype:107",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "107",
+      "skos:prefLabel": "Partner Card - Columbia"
     },
     {
       "@id": "ptype:106",
@@ -280,97 +382,6 @@
       ],
       "skos:notation": "106",
       "skos:prefLabel": "NYPL Department"
-    },
-    {
-      "@id": "ptype:61",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "61",
-      "skos:prefLabel": "Child 0-12 All Access Metro"
-    },
-    {
-      "@id": "ptype:100",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "100",
-      "skos:prefLabel": "INACTIVE PATRON"
-    },
-    {
-      "@id": "ptype:70",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "70",
-      "skos:prefLabel": "Disabled Metro NY (3 Year)"
-    },
-    {
-      "@id": "ptype:3",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "3",
-      "skos:prefLabel": "SimplyE Non-Metro"
-    },
-    {
-      "@id": "ptype:150",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "150",
-      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
-    },
-    {
-      "@id": "ptype:101",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "101",
-      "skos:prefLabel": "PENDING DISPUTE"
-    },
-    {
-      "@id": "ptype:149",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "149",
-      "skos:prefLabel": "MyLibraryNYC Educator Queens"
-    },
-    {
-      "@id": "ptype:108",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "108",
-      "skos:prefLabel": "Partner Card - Princeton"
-    },
-    {
-      "@id": "ptype:30",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "30",
-      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
-    },
-    {
-      "@id": "ptype:50",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "50",
-      "skos:prefLabel": "Teen 13-17 Metro"
-    },
-    {
-      "@id": "ptype:80",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "80",
-      "skos:prefLabel": "CUNY Graduate Center (9/30)"
-    },
-    {
-      "@id": "ptype:0",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "0",
-      "skos:prefLabel": "Undefined (Do Not Use)"
-    },
-    {
-      "@id": "ptype:81",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "81",
-      "skos:prefLabel": "MaRLI (9/30)"
     }
   ]
 }

--- a/vocabularies/json-ld/patronTypes.json
+++ b/vocabularies/json-ld/patronTypes.json
@@ -7,22 +7,65 @@
   },
   "@graph": [
     {
-      "@id": "ptype:10",
+      "@id": "ptype:84",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "10",
-      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+      "skos:notation": "84",
+      "skos:prefLabel": "Visitor (3 Month Limited Use)"
     },
     {
       "@id": "ptype:61",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "61",
       "skos:prefLabel": "Child 0-12 All Access Metro"
     },
     {
+      "@id": "ptype:153",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "153",
+      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
+    },
+    {
+      "@id": "ptype:50",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "50",
+      "skos:prefLabel": "Teen 13-17 Metro"
+    },
+    {
+      "@id": "ptype:80",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "80",
+      "skos:prefLabel": "CUNY Graduate Center (9/30)"
+    },
+    {
+      "@id": "ptype:107",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "107",
+      "skos:prefLabel": "Partner Card - Columbia"
+    },
+    {
+      "@id": "ptype:51",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "51",
+      "skos:prefLabel": "Teen 13-17 NY State"
+    },
+    {
       "@id": "ptype:86",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "malw",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
@@ -31,87 +74,9 @@
       "skos:prefLabel": "Wertheim Scholar"
     },
     {
-      "@id": "ptype:81",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "81",
-      "skos:prefLabel": "MaRLI (9/30)"
-    },
-    {
-      "@id": "ptype:101",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "101",
-      "skos:prefLabel": "PENDING DISPUTE"
-    },
-    {
-      "@id": "ptype:62",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "62",
-      "skos:prefLabel": "Child 0-12 Juv Only NY State"
-    },
-    {
-      "@id": "ptype:63",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "63",
-      "skos:prefLabel": "Child 0-12 All Access NY State"
-    },
-    {
-      "@id": "ptype:78",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "78",
-      "skos:prefLabel": "Short Term Scholar"
-    },
-    {
-      "@id": "ptype:11",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "11",
-      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
-    },
-    {
-      "@id": "ptype:51",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "51",
-      "skos:prefLabel": "Teen 13-17 NY State"
-    },
-    {
-      "@id": "ptype:75",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "75",
-      "skos:prefLabel": "Schomburg Scholar"
-    },
-    {
-      "@id": "ptype:88",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Research",
-        "Scholar"
-      ],
-      "skos:notation": "88",
-      "skos:prefLabel": "Shoichi Noma Scholar"
-    },
-    {
-      "@id": "ptype:72",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "72",
-      "skos:prefLabel": "Homebound NYC (3 Year)"
-    },
-    {
       "@id": "ptype:108",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "108",
       "skos:prefLabel": "Partner Card - Princeton"
@@ -119,6 +84,7 @@
     {
       "@id": "ptype:89",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "malc",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
@@ -127,8 +93,57 @@
       "skos:prefLabel": "Cullman Scholar"
     },
     {
+      "@id": "ptype:73",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "73",
+      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:2",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "2",
+      "skos:prefLabel": "SimplyE Metro"
+    },
+    {
+      "@id": "ptype:11",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "11",
+      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
+    },
+    {
+      "@id": "ptype:31",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "31",
+      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
+    },
+    {
+      "@id": "ptype:94",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "94",
+      "skos:prefLabel": "MaRLI NYU"
+    },
+    {
+      "@id": "ptype:95",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "95",
+      "skos:prefLabel": "MaRLI Columbia"
+    },
+    {
       "@id": "ptype:87",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "mala",
       "nypl:deliveryLocationAccess": [
         "Research",
         "Scholar"
@@ -137,235 +152,268 @@
       "skos:prefLabel": "Allen Scholar"
     },
     {
-      "@id": "ptype:152",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "152",
-      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
-    },
-    {
-      "@id": "ptype:93",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "93",
-      "skos:prefLabel": "Research Borrower"
-    },
-    {
-      "@id": "ptype:91",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "91",
-      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
-    },
-    {
-      "@id": "ptype:83",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "83",
-      "skos:prefLabel": "Temporary (3 Day Research Only)"
-    },
-    {
-      "@id": "ptype:100",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "100",
-      "skos:prefLabel": "INACTIVE PATRON"
-    },
-    {
-      "@id": "ptype:50",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "50",
-      "skos:prefLabel": "Teen 13-17 Metro"
-    },
-    {
-      "@id": "ptype:106",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "106",
-      "skos:prefLabel": "NYPL Department"
-    },
-    {
-      "@id": "ptype:3",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "3",
-      "skos:prefLabel": "SimplyE Non-Metro"
-    },
-    {
-      "@id": "ptype:31",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "31",
-      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
-    },
-    {
-      "@id": "ptype:95",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "95",
-      "skos:prefLabel": "MaRLI Columbia"
-    },
-    {
-      "@id": "ptype:120",
-      "@type": "nypl:PatronType",
-      "skos:notation": "120",
-      "skos:prefLabel": "Easy Borrowing AdultPilot"
-    },
-    {
-      "@id": "ptype:84",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "84",
-      "skos:prefLabel": "Visitor (3 Month Limited Use)"
-    },
-    {
-      "@id": "ptype:149",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "149",
-      "skos:prefLabel": "MyLibraryNYC Educator Queens"
-    },
-    {
       "@id": "ptype:121",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "skos:notation": "121",
       "skos:prefLabel": "Easy Borrowing SeniorPilot"
     },
     {
-      "@id": "ptype:76",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "76",
-      "skos:prefLabel": "SASB Scholar RM 217"
-    },
-    {
-      "@id": "ptype:0",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "0",
-      "skos:prefLabel": "Undefined (Do Not Use)"
-    },
-    {
-      "@id": "ptype:1",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "1",
-      "skos:prefLabel": "Web Applicant (No Borrowing)"
-    },
-    {
       "@id": "ptype:151",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "151",
       "skos:prefLabel": "MyLibraryNYC Educator"
     },
     {
-      "@id": "ptype:70",
+      "@id": "ptype:101",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "70",
-      "skos:prefLabel": "Disabled Metro NY (3 Year)"
-    },
-    {
-      "@id": "ptype:90",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "90",
-      "skos:prefLabel": "Organization (1 Year Only)"
-    },
-    {
-      "@id": "ptype:60",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "60",
-      "skos:prefLabel": "Child 0-12 Juv Only Metro"
-    },
-    {
-      "@id": "ptype:82",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": [
-        "Scholar",
-        "Research"
-      ],
-      "skos:notation": "82",
-      "skos:prefLabel": "Scholar"
-    },
-    {
-      "@id": "ptype:30",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "30",
-      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
-    },
-    {
-      "@id": "ptype:2",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "2",
-      "skos:prefLabel": "SimplyE Metro"
-    },
-    {
-      "@id": "ptype:153",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "153",
-      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
-    },
-    {
-      "@id": "ptype:73",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "73",
-      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
-    },
-    {
-      "@id": "ptype:150",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "150",
-      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
-    },
-    {
-      "@id": "ptype:94",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "94",
-      "skos:prefLabel": "MaRLI NYU"
-    },
-    {
-      "@id": "ptype:107",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "107",
-      "skos:prefLabel": "Partner Card - Columbia"
-    },
-    {
-      "@id": "ptype:116",
-      "@type": "nypl:PatronType",
-      "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "116",
-      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+      "skos:notation": "101",
+      "skos:prefLabel": "PENDING DISPUTE"
     },
     {
       "@id": "ptype:85",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
       "skos:notation": "85",
       "skos:prefLabel": "ILL - Research"
     },
     {
-      "@id": "ptype:80",
+      "@id": "ptype:150",
       "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
       "nypl:deliveryLocationAccess": "Research",
-      "skos:notation": "80",
-      "skos:prefLabel": "CUNY Graduate Center (9/30)"
+      "skos:notation": "150",
+      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
+    },
+    {
+      "@id": "ptype:106",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "106",
+      "skos:prefLabel": "NYPL Department"
+    },
+    {
+      "@id": "ptype:76",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "mal17",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "76",
+      "skos:prefLabel": "SASB Scholar RM 217"
+    },
+    {
+      "@id": "ptype:90",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "90",
+      "skos:prefLabel": "Organization (1 Year Only)"
+    },
+    {
+      "@id": "ptype:62",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "62",
+      "skos:prefLabel": "Child 0-12 Juv Only NY State"
+    },
+    {
+      "@id": "ptype:72",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "72",
+      "skos:prefLabel": "Homebound NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:81",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "81",
+      "skos:prefLabel": "MaRLI (9/30)"
+    },
+    {
+      "@id": "ptype:120",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "skos:notation": "120",
+      "skos:prefLabel": "Easy Borrowing AdultPilot"
+    },
+    {
+      "@id": "ptype:93",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "93",
+      "skos:prefLabel": "Research Borrower"
+    },
+    {
+      "@id": "ptype:10",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "10",
+      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:91",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "91",
+      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
+    },
+    {
+      "@id": "ptype:1",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "1",
+      "skos:prefLabel": "Web Applicant (No Borrowing)"
+    },
+    {
+      "@id": "ptype:63",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "63",
+      "skos:prefLabel": "Child 0-12 All Access NY State"
+    },
+    {
+      "@id": "ptype:88",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "maln",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "88",
+      "skos:prefLabel": "Shoichi Noma Scholar"
+    },
+    {
+      "@id": "ptype:60",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "60",
+      "skos:prefLabel": "Child 0-12 Juv Only Metro"
+    },
+    {
+      "@id": "ptype:3",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "3",
+      "skos:prefLabel": "SimplyE Non-Metro"
+    },
+    {
+      "@id": "ptype:149",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "149",
+      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+    },
+    {
+      "@id": "ptype:100",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "100",
+      "skos:prefLabel": "INACTIVE PATRON"
+    },
+    {
+      "@id": "ptype:75",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "75",
+      "skos:prefLabel": "Schomburg Scholar"
+    },
+    {
+      "@id": "ptype:78",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "78",
+      "skos:prefLabel": "Short Term Scholar"
+    },
+    {
+      "@id": "ptype:0",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "0",
+      "skos:prefLabel": "Undefined (Do Not Use)"
+    },
+    {
+      "@id": "ptype:152",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "152",
+      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
+    },
+    {
+      "@id": "ptype:116",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "116",
+      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+    },
+    {
+      "@id": "ptype:30",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "30",
+      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:83",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "83",
+      "skos:prefLabel": "Temporary (3 Day Research Only)"
+    },
+    {
+      "@id": "ptype:82",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "82",
+      "skos:prefLabel": "Scholar"
+    },
+    {
+      "@id": "ptype:70",
+      "@type": "nypl:PatronType",
+      "nypl:deliverableTo": "None",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "70",
+      "skos:prefLabel": "Disabled Metro NY (3 Year)"
     }
   ]
 }

--- a/vocabularies/scripts/serialize-patronTypes.py
+++ b/vocabularies/scripts/serialize-patronTypes.py
@@ -23,11 +23,14 @@ for r in reader:
     preflabel = rdflib.Literal(r['skos:prefLabel'])
     notation = rdflib.Literal(r['skos:notation'])
     access = access = r['nypl:deliveryLocationAccess'].split(';')
+    deliveryLocations = r['nypl:deliverableTo']
     ptype = nyplPatronType + str(id)
 
     g.add((ptype, RDF.type, nypl.PatronType))
     g.add((ptype, SKOS.prefLabel, preflabel))
     g.add((ptype, SKOS.notation, notation))
+    if r['nypl:deliverableTo'] != '':
+        g.add((ptype, nypl.deliverableTo, rdflib.Literal(ptype)))
     if r['nypl:deliveryLocationAccess'] != '':
         for a in access:
             if a != '':

--- a/vocabularies/scripts/serialize-patronTypes.py
+++ b/vocabularies/scripts/serialize-patronTypes.py
@@ -30,7 +30,7 @@ for r in reader:
     g.add((ptype, SKOS.prefLabel, preflabel))
     g.add((ptype, SKOS.notation, notation))
     if r['nypl:deliverableTo'] != '':
-        g.add((ptype, nypl.deliverableTo, rdflib.Literal(ptype)))
+        g.add((ptype, nypl.deliverableTo, rdflib.Literal(deliveryLocations)))
     if r['nypl:deliveryLocationAccess'] != '':
         for a in access:
             if a != '':

--- a/vocabularies/scripts/serialize-patronTypes.py
+++ b/vocabularies/scripts/serialize-patronTypes.py
@@ -29,7 +29,7 @@ for r in reader:
     g.add((ptype, RDF.type, nypl.PatronType))
     g.add((ptype, SKOS.prefLabel, preflabel))
     g.add((ptype, SKOS.notation, notation))
-    if r['nypl:deliverableTo'] != '':
+    if r['nypl:deliverableTo'] is not None:
         g.add((ptype, nypl.deliverableTo, rdflib.Literal(deliveryLocations)))
     if r['nypl:deliveryLocationAccess'] != '':
         for a in access:

--- a/vocabularies/scripts/serialize-patronTypes.py
+++ b/vocabularies/scripts/serialize-patronTypes.py
@@ -14,6 +14,8 @@ nypl = Namespace('http://data.nypl.org/nypl-core/')
 skos = Namespace('http://www.w3.org/2004/02/skos/core#')
 nyplOrg = rdflib.URIRef('http://data.nypl.org/orgs/')
 nyplPatronType = rdflib.URIRef('http://data.nypl.org/patronTypes/')
+nyplLocation = rdflib.URIRef('http://data.nypl.org/locations/')
+
 
 g = Graph()
 
@@ -23,14 +25,15 @@ for r in reader:
     preflabel = rdflib.Literal(r['skos:prefLabel'])
     notation = rdflib.Literal(r['skos:notation'])
     access = access = r['nypl:deliveryLocationAccess'].split(';')
-    deliveryLocations = r['nypl:deliverableTo']
+    deliveryLocation = r['nypl:scholarRoom']
     ptype = nyplPatronType + str(id)
 
     g.add((ptype, RDF.type, nypl.PatronType))
     g.add((ptype, SKOS.prefLabel, preflabel))
     g.add((ptype, SKOS.notation, notation))
-    if r['nypl:deliverableTo'] is not None:
-        g.add((ptype, nypl.deliverableTo, rdflib.Literal(deliveryLocations)))
+    if r['nypl:scholarRoom'] is not None:
+        g.add((ptype, nypl.scholarRoom, nyplLocation +
+               rdflib.Literal(deliveryLocation)))
     if r['nypl:deliveryLocationAccess'] != '':
         for a in access:
             if a != '':
@@ -41,7 +44,8 @@ z = open('../json-ld/patronTypes.json', 'wb')
 context = {"nypl": "http://data.nypl.org/nypl-core/",
            "skos": "http://www.w3.org/2004/02/skos/core#",
            "nyplOrg": "http://data.nypl.org/orgs/",
-           "ptype": "http://data.nypl.org/patronTypes/"}
+           "ptype": "http://data.nypl.org/patronTypes/",
+           "nyplLocation": 'http://data.nypl.org/locations/'}
 z.write(g.serialize(format="json-ld", context=context, encoding="utf-8"))
 
 z.close()


### PR DESCRIPTION
- added scholarRoom prop to patrontypes csv
- updated serializer to add scholarRoom prop
Comparing patronTypes in SCC-3952/add-scholar-delivery to master
Keys Added: 0
Keys Deleted: 0
Keys Altered: 5

ALTERED KEY: ptype:87
  Added Item: root['nypl:scholarRoom']

ALTERED KEY: ptype:86
  Added Item: root['nypl:scholarRoom']

ALTERED KEY: ptype:88
  Added Item: root['nypl:scholarRoom']

ALTERED KEY: ptype:89
  Added Item: root['nypl:scholarRoom']

ALTERED KEY: ptype:76
  Added Item: root['nypl:scholarRoom']