### PR TITLE
Scc 4342/revert pf

### DIFF
--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -100,7 +100,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OE;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NC;ND;NE;NF;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OA;OC;OE;OD;ON;OW,true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD;ON,true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -100,7 +100,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OE;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD;ON,true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD;true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -100,7 +100,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OE;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD;true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD,true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/csv/recapCustomerCodes.csv
+++ b/vocabularies/csv/recapCustomerCodes.csv
@@ -100,7 +100,7 @@ JM,JM,JM,,false,0002
 PA,PA,Firestone LIbrary,NB;ND;NG;NJ;NM;NH;NP;SR;OA;OC;ON;OW;OE;OD,true,0003
 PB,PB,Firestone Library Use Only,,true,0003
 PE,PE,Princeton Dark Storage,,false,0003
-PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD,true,0003
+PF,PF,"Firestone Library, Microforms",NC;NE;NF;NG;NH;NI;NJ;NK;NM;NN;NO;NP;NR;NS;NT;NV;NX;NY;NZ;SA;SM;SP;SR;OE;OD,true,0003
 PG,PG,Rare Books,,false,0003
 PH,PH,Mudd Manuscript Library,,false,0003
 PJ,PJ,Marquand Library,,true,0003

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,77 +7,7 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GN",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -86,99 +16,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CA",
-      "skos:prefLabel": "Science & Engineering Lib (NWC)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
+      "skos:notation": "BL",
+      "skos:prefLabel": "Barnard Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
@@ -194,448 +33,11 @@
       "skos:prefLabel": "Princeton Dark Storage"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QV",
-      "skos:prefLabel": "Video Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CP",
-      "skos:prefLabel": "CP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "OE",
-      "skos:prefLabel": "SASB Scholar Room 223"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
       },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
-      "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -643,75 +45,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HY",
-      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+      "skos:notation": "ND",
+      "skos:prefLabel": "SASB Map Division"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/RR",
@@ -725,113 +60,6 @@
       },
       "skos:notation": "RR",
       "skos:prefLabel": "ReCAP Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PF",
@@ -910,26 +138,62 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/OD"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+          "@id": "http://data.nypl.org/recapCustomerCodes/true"
         }
       ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "0003"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:None"
       },
       "skos:notation": "PF",
       "skos:prefLabel": "Firestone Library, Microforms"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CV",
+      "skos:prefLabel": "Butler Media Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OL",
+      "skos:prefLabel": "Media Preservation Lab"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
@@ -958,16 +222,16 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/OC"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/OE"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
         }
       ],
       "nypl:eddRequestable": {
@@ -975,23 +239,10 @@
         "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0001"
+        "@id": "nyplOrg:0004"
       },
-      "skos:notation": "JO",
-      "skos:prefLabel": "JSTOR Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/AR",
@@ -1051,103 +302,7 @@
       "skos:prefLabel": "Avery Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -1197,1468 +352,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CD",
-      "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HR",
-      "skos:prefLabel": "HSL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NX",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GC",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NP",
-      "skos:prefLabel": "LPA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HV",
-      "skos:prefLabel": "Harvard ReCAP Items"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BL",
-      "skos:prefLabel": "Barnard Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AD",
-      "skos:prefLabel": "Avery Drawings & Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PA",
-      "skos:prefLabel": "Firestone LIbrary"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JS",
-      "skos:prefLabel": "SIBL De-duping candidates"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CV",
-      "skos:prefLabel": "Butler Media Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PL",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OZ",
-      "skos:prefLabel": "SASB no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OL",
-      "skos:prefLabel": "Media Preservation Lab"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EV",
-      "skos:prefLabel": "East Asian Vernacular"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NA",
-      "skos:prefLabel": "NA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PN",
-      "skos:prefLabel": "Lewis Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HK",
-      "skos:prefLabel": "KSG LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ND",
-      "skos:prefLabel": "SASB Map Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MZ",
-      "skos:prefLabel": "ReCAP Coordinator"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
+      "skos:notation": "GUT",
+      "skos:prefLabel": "GUTMAN LIBRARY"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NW",
@@ -2718,25 +413,12 @@
       "skos:prefLabel": "Donnell Children's Room"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
@@ -2751,6 +433,12 @@
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/OA"
@@ -2778,132 +466,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
+      "skos:notation": "JS",
+      "skos:prefLabel": "SIBL De-duping candidates"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "GUT",
-      "skos:prefLabel": "GUTMAN LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:0002"
       },
-      "skos:notation": "PB",
-      "skos:prefLabel": "Firestone Library Use Only"
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2912,78 +492,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QL",
-      "skos:prefLabel": "East Asian Microforms"
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HSdupe",
-      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -3036,27 +549,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CU",
-      "skos:prefLabel": "CU Standard"
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "FL",
-      "skos:prefLabel": "FINE ARTS LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3065,102 +562,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NR",
-      "skos:prefLabel": "SASB Rare Book Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NB",
@@ -3220,6 +623,728 @@
       "skos:prefLabel": "SIBL"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "OE",
+      "skos:prefLabel": "SASB Scholar Room 223"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HV",
+      "skos:prefLabel": "Harvard ReCAP Items"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HK",
+      "skos:prefLabel": "KSG LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MZ",
+      "skos:prefLabel": "ReCAP Coordinator"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GN",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HR",
+      "skos:prefLabel": "HSL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HSdupe",
+      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PT",
+      "skos:prefLabel": "Engineering Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PL",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PB",
+      "skos:prefLabel": "Firestone Library Use Only"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/HW",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
@@ -3274,20 +1399,33 @@
       "skos:prefLabel": "WIDENER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3296,8 +1434,802 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "FL",
+      "skos:prefLabel": "FINE ARTS LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HY",
+      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PN",
+      "skos:prefLabel": "Lewis Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GC",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CA",
+      "skos:prefLabel": "Science & Engineering Lib (NWC)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EV",
+      "skos:prefLabel": "East Asian Vernacular"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CP",
+      "skos:prefLabel": "CP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PA",
+      "skos:prefLabel": "Firestone LIbrary"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OZ",
+      "skos:prefLabel": "SASB no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
@@ -3354,20 +2286,7 @@
       "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3376,11 +2295,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "MP",
-      "skos:prefLabel": "Monographic Processing"
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3389,8 +2308,412 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PT",
-      "skos:prefLabel": "Engineering Library"
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JO",
+      "skos:prefLabel": "JSTOR Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
@@ -3447,7 +2770,7 @@
       "skos:prefLabel": "TOZZER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3456,34 +2779,21 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CF",
@@ -3499,6 +2809,400 @@
       "skos:prefLabel": "Cold Storage Film"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CD",
+      "skos:prefLabel": "CD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NA",
+      "skos:prefLabel": "NA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QL",
+      "skos:prefLabel": "East Asian Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NP",
+      "skos:prefLabel": "LPA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NX",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/NI",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -3512,7 +3216,7 @@
       "skos:prefLabel": "LSC Special Formats Processing"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3521,8 +3225,304 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NR",
+      "skos:prefLabel": "SASB Rare Book Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CU",
+      "skos:prefLabel": "CU Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MP",
+      "skos:prefLabel": "Monographic Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QV",
+      "skos:prefLabel": "Video Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AD",
+      "skos:prefLabel": "Avery Drawings & Archives"
     }
   ]
 }

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,7 +7,7 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -16,108 +16,15 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
       },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CD",
-      "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
-      "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -125,642 +32,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MCZ",
-      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BL",
-      "skos:prefLabel": "Barnard Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PN",
-      "skos:prefLabel": "Lewis Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GN",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HW",
-      "skos:prefLabel": "WIDENER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NR",
-      "skos:prefLabel": "SASB Rare Book Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AR",
-      "skos:prefLabel": "Avery Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NW",
@@ -820,7 +93,7 @@
       "skos:prefLabel": "Donnell Children's Room"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -829,11 +102,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -842,11 +115,50 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NX",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -896,11 +208,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
+      "skos:notation": "HY",
+      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QL",
+      "skos:prefLabel": "East Asian Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -909,38 +234,15 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
       },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
-      "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -948,12 +250,110 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
       "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "GUT",
+      "skos:prefLabel": "GUTMAN LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
@@ -961,11 +361,120 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
+      "skos:notation": "EV",
+      "skos:prefLabel": "East Asian Vernacular"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AR",
+      "skos:prefLabel": "Avery Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BL",
+      "skos:prefLabel": "Barnard Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -974,15 +483,124 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OL",
-      "skos:prefLabel": "Media Preservation Lab"
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NA",
+      "skos:prefLabel": "NA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
       },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PN",
+      "skos:prefLabel": "Lewis Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -990,11 +608,199 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "ND",
-      "skos:prefLabel": "SASB Map Division"
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HW",
+      "skos:prefLabel": "WIDENER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MCZ",
+      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PB",
+      "skos:prefLabel": "Firestone Library Use Only"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NR",
+      "skos:prefLabel": "SASB Rare Book Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "TZ",
+      "skos:prefLabel": "TOZZER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1003,34 +809,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/JO",
@@ -1090,7 +870,7 @@
       "skos:prefLabel": "JSTOR Restricted"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1099,24 +879,63 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:0002"
       },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
+      "skos:notation": "CF",
+      "skos:prefLabel": "Cold Storage Film"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1125,8 +944,1186 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OL",
+      "skos:prefLabel": "Media Preservation Lab"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "OE",
+      "skos:prefLabel": "SASB Scholar Room 223"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PA",
+      "skos:prefLabel": "Firestone LIbrary"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CA",
+      "skos:prefLabel": "Science & Engineering Lib (NWC)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "FL",
+      "skos:prefLabel": "FINE ARTS LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NP",
+      "skos:prefLabel": "LPA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CV",
+      "skos:prefLabel": "Butler Media Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HR",
+      "skos:prefLabel": "HSL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NI",
+      "skos:prefLabel": "LSC Special Formats Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CU",
+      "skos:prefLabel": "CU Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PF",
@@ -1155,6 +2152,9 @@
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NK"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NN"
@@ -1216,238 +2216,7 @@
       "skos:prefLabel": "Firestone Library, Microforms"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NA",
-      "skos:prefLabel": "NA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "RR",
-      "skos:prefLabel": "ReCAP Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "GUT",
-      "skos:prefLabel": "GUTMAN LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "OE",
-      "skos:prefLabel": "SASB Scholar Room 223"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NP",
-      "skos:prefLabel": "LPA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1456,40 +2225,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "JQ",
-      "skos:prefLabel": "Princeton Dark Storage"
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1498,68 +2238,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CU",
-      "skos:prefLabel": "CU Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1568,428 +2251,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QL",
-      "skos:prefLabel": "East Asian Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PB",
-      "skos:prefLabel": "Firestone Library Use Only"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EV",
-      "skos:prefLabel": "East Asian Vernacular"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HK",
-      "skos:prefLabel": "KSG LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1998,421 +2264,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NB",
-      "skos:prefLabel": "SIBL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HY",
-      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HR",
-      "skos:prefLabel": "HSL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CF",
-      "skos:prefLabel": "Cold Storage Film"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+      "skos:notation": "OZ",
+      "skos:prefLabel": "SASB no Sierra holds"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CP",
@@ -2428,141 +2281,33 @@
       "skos:prefLabel": "CP"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "TZ",
-      "skos:prefLabel": "TOZZER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0003"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2571,30 +2316,40 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "RR",
+      "skos:prefLabel": "ReCAP Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
       },
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2603,379 +2358,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NX",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PA",
-      "skos:prefLabel": "Firestone LIbrary"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QV",
-      "skos:prefLabel": "Video Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CA",
-      "skos:prefLabel": "Science & Engineering Lib (NWC)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AD",
-      "skos:prefLabel": "Avery Drawings & Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PT",
-      "skos:prefLabel": "Engineering Library"
+      "skos:notation": "ND",
+      "skos:prefLabel": "SASB Map Division"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
@@ -2991,7 +2375,7 @@
       "skos:prefLabel": "ReCAP Coordinator"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3000,11 +2384,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3013,21 +2397,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/JS",
@@ -3087,6 +2458,286 @@
       "skos:prefLabel": "SIBL De-duping candidates"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MP",
+      "skos:prefLabel": "Monographic Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/GC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
@@ -3144,7 +2795,201 @@
       "skos:prefLabel": "Government Documents"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GN",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PT",
+      "skos:prefLabel": "Engineering Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NB",
+      "skos:prefLabel": "SIBL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HK",
+      "skos:prefLabel": "KSG LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3153,8 +2998,34 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CV",
-      "skos:prefLabel": "Butler Media Collection"
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CD",
+      "skos:prefLabel": "CD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
@@ -3211,6 +3082,172 @@
       "skos:prefLabel": "CABOT SCIENCE LIBRARY"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AD",
+      "skos:prefLabel": "Avery Drawings & Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/HV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
@@ -3265,33 +3302,7 @@
       "skos:prefLabel": "Harvard ReCAP Items"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NI",
-      "skos:prefLabel": "LSC Special Formats Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OZ",
-      "skos:prefLabel": "SASB no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3300,24 +3311,86 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0004"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "FL",
-      "skos:prefLabel": "FINE ARTS LIBRARY"
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PL",
@@ -3333,116 +3406,46 @@
       "skos:prefLabel": "East Asian Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
       },
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
+      "skos:notation": "QV",
+      "skos:prefLabel": "Video Collection"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -3492,24 +3495,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MP",
-      "skos:prefLabel": "Monographic Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3518,8 +3508,21 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JQ",
+      "skos:prefLabel": "Princeton Dark Storage"
     }
   ]
 }

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,6 +7,317 @@
   },
   "@graph": [
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CD",
+      "skos:prefLabel": "CD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MCZ",
+      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/BL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -20,7 +331,7 @@
       "skos:prefLabel": "Barnard Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -29,8 +340,642 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "JQ",
-      "skos:prefLabel": "Princeton Dark Storage"
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PN",
+      "skos:prefLabel": "Lewis Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GN",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HW",
+      "skos:prefLabel": "WIDENER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NR",
+      "skos:prefLabel": "SASB Rare Book Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AR",
+      "skos:prefLabel": "Avery Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NW",
+      "skos:prefLabel": "Donnell Children's Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OL",
+      "skos:prefLabel": "Media Preservation Lab"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/ND",
@@ -49,7 +994,129 @@
       "skos:prefLabel": "SASB Map Division"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JO",
+      "skos:prefLabel": "JSTOR Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -58,8 +1125,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "RR",
-      "skos:prefLabel": "ReCAP Reading Room"
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PF",
@@ -136,2703 +1203,17 @@
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/true"
         }
       ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
-        "@value": "0003"
+        "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:None"
+        "@id": "nyplOrg:0003"
       },
       "skos:notation": "PF",
       "skos:prefLabel": "Firestone Library, Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CV",
-      "skos:prefLabel": "Butler Media Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OL",
-      "skos:prefLabel": "Media Preservation Lab"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AR",
-      "skos:prefLabel": "Avery Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "GUT",
-      "skos:prefLabel": "GUTMAN LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NW",
-      "skos:prefLabel": "Donnell Children's Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JS",
-      "skos:prefLabel": "SIBL De-duping candidates"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NB",
-      "skos:prefLabel": "SIBL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "OE",
-      "skos:prefLabel": "SASB Scholar Room 223"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HV",
-      "skos:prefLabel": "Harvard ReCAP Items"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HK",
-      "skos:prefLabel": "KSG LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MZ",
-      "skos:prefLabel": "ReCAP Coordinator"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GN",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HR",
-      "skos:prefLabel": "HSL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HSdupe",
-      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PT",
-      "skos:prefLabel": "Engineering Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PL",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PB",
-      "skos:prefLabel": "Firestone Library Use Only"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HW",
-      "skos:prefLabel": "WIDENER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "FL",
-      "skos:prefLabel": "FINE ARTS LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HY",
-      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PN",
-      "skos:prefLabel": "Lewis Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GC",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CA",
-      "skos:prefLabel": "Science & Engineering Lib (NWC)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EV",
-      "skos:prefLabel": "East Asian Vernacular"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CP",
-      "skos:prefLabel": "CP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PA",
-      "skos:prefLabel": "Firestone LIbrary"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OZ",
-      "skos:prefLabel": "SASB no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MCZ",
-      "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JO",
-      "skos:prefLabel": "JSTOR Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "TZ",
-      "skos:prefLabel": "TOZZER LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CF",
-      "skos:prefLabel": "Cold Storage Film"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CD",
-      "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NA",
@@ -2892,23 +1273,36 @@
       "skos:prefLabel": "NA"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
+      "skos:notation": "RR",
+      "skos:prefLabel": "ReCAP Reading Room"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
       },
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2917,11 +1311,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -2971,11 +1365,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
+      "skos:notation": "GUT",
+      "skos:prefLabel": "GUTMAN LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2984,85 +1378,21 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QL",
-      "skos:prefLabel": "East Asian Microforms"
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
+      "skos:notation": "OE",
+      "skos:prefLabel": "SASB Scholar Room 223"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3071,8 +1401,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NP",
@@ -3091,7 +1421,20 @@
       "skos:prefLabel": "LPA"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3100,11 +1443,53 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JQ",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3113,146 +1498,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NX",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NI",
-      "skos:prefLabel": "LSC Special Formats Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NR",
-      "skos:prefLabel": "SASB Rare Book Division"
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CU",
@@ -3312,7 +1559,7 @@
       "skos:prefLabel": "CU Standard"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3321,11 +1568,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3334,24 +1581,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0001"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
+      "skos:notation": "QL",
+      "skos:prefLabel": "East Asian Microforms"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3360,11 +1607,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
+      "skos:notation": "PB",
+      "skos:prefLabel": "Firestone Library Use Only"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -3417,11 +1664,332 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
+      "skos:notation": "EV",
+      "skos:prefLabel": "East Asian Vernacular"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HK",
+      "skos:prefLabel": "KSG LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3430,11 +1998,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3443,11 +2024,59 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3456,11 +2085,81 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NB",
+      "skos:prefLabel": "SIBL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3469,11 +2168,215 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HY",
+      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HR",
+      "skos:prefLabel": "HSL Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3482,11 +2385,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "MP",
-      "skos:prefLabel": "Monographic Processing"
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CF",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3495,8 +2398,519 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
+      "skos:notation": "CF",
+      "skos:prefLabel": "Cold Storage Film"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CP",
+      "skos:prefLabel": "CP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/TZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "TZ",
+      "skos:prefLabel": "TOZZER LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NX",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PA",
+      "skos:prefLabel": "Firestone LIbrary"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/QV",
@@ -3512,6 +2926,19 @@
       "skos:prefLabel": "Video Collection"
     },
     {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CA",
+      "skos:prefLabel": "Science & Engineering Lib (NWC)"
+    },
+    {
       "@id": "http://data.nypl.org/recapCustomerCodes/AD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
@@ -3523,6 +2950,576 @@
       },
       "skos:notation": "AD",
       "skos:prefLabel": "Avery Drawings & Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PT",
+      "skos:prefLabel": "Engineering Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MZ",
+      "skos:prefLabel": "ReCAP Coordinator"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JS",
+      "skos:prefLabel": "SIBL De-duping candidates"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GC",
+      "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CV",
+      "skos:prefLabel": "Butler Media Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HSdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HSdupe",
+      "skos:prefLabel": "CABOT SCIENCE LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HV",
+      "skos:prefLabel": "Harvard ReCAP Items"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NI",
+      "skos:prefLabel": "LSC Special Formats Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OZ",
+      "skos:prefLabel": "SASB no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/FL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "FL",
+      "skos:prefLabel": "FINE ARTS LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PL",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MP",
+      "skos:prefLabel": "Monographic Processing"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
     }
   ]
 }

--- a/vocabularies/json-ld/recapCustomerCodes.json
+++ b/vocabularies/json-ld/recapCustomerCodes.json
@@ -7,33 +7,7 @@
   },
   "@graph": [
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CH",
-      "skos:prefLabel": "CH"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CL",
-      "skos:prefLabel": "CL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -42,302 +16,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NG",
-      "skos:prefLabel": "SASB Art Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NC",
-      "skos:prefLabel": "LSC BookOps Cataloging"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QT",
-      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ND",
-      "skos:prefLabel": "SASB Map Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NB",
-      "skos:prefLabel": "SIBL"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "GP",
-      "skos:prefLabel": "GP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PZ",
-      "skos:prefLabel": "Marquand Library Rare"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BZ",
-      "skos:prefLabel": "Preservation Project"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PW",
-      "skos:prefLabel": "Architecture Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BC",
-      "skos:prefLabel": "Bibliographic Control Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NJ",
-      "skos:prefLabel": "SASB Jewish Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JO",
-      "skos:prefLabel": "JSTOR Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QK",
-      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+      "skos:notation": "OP",
+      "skos:prefLabel": "LPA no Sierra holds"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/GN",
@@ -397,7 +77,7 @@
       "skos:prefLabel": "Government Documents"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -406,37 +86,115 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "RH",
-      "skos:prefLabel": "Human Rights Watch"
+      "skos:notation": "JM",
+      "skos:prefLabel": "JM"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
+      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0001"
+        "@id": "nyplOrg:0002"
       },
-      "skos:notation": "NI",
-      "skos:prefLabel": "LSC Special Formats Processing"
+      "skos:notation": "SW",
+      "skos:prefLabel": "Social Work Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0001"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "OA",
-      "skos:prefLabel": "SASB Allen Room"
+      "skos:notation": "PV",
+      "skos:prefLabel": "PV"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CA",
+      "skos:prefLabel": "Science & Engineering Lib (NWC)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CM",
+      "skos:prefLabel": "Master Microfilm"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BZ",
+      "skos:prefLabel": "Preservation Project"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "OH",
+      "skos:prefLabel": "Oral History"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PS",
+      "skos:prefLabel": "Lewis Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "JQ",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -486,37 +244,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "HV",
-      "skos:prefLabel": "Harvard ReCAP Items"
+      "skos:notation": "AH",
+      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "RS",
-      "skos:prefLabel": "Rare Books & Manuscripts"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PJ",
-      "skos:prefLabel": "Marquand Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -525,24 +257,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QP",
-      "skos:prefLabel": "ReCAP/Princeton Preservation"
+      "skos:notation": "QD",
+      "skos:prefLabel": "QD"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LE",
-      "skos:prefLabel": "Lehman Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -551,88 +270,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QB",
-      "skos:prefLabel": "QB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SR",
-      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EA",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "MLdupe",
-      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+      "skos:notation": "PH",
+      "skos:prefLabel": "Mudd Manuscript Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/QV",
@@ -648,7 +287,162 @@
       "skos:prefLabel": "Video Collection"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "LD",
+      "skos:prefLabel": "LD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QP",
+      "skos:prefLabel": "ReCAP/Princeton Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PM",
+      "skos:prefLabel": "Stokes Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CP",
+      "skos:prefLabel": "CP"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HL",
+      "skos:prefLabel": "HARVARD LAW LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BU",
+      "skos:prefLabel": "Butler Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "ML",
+      "skos:prefLabel": "Mathematics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "OE",
+      "skos:prefLabel": "SASB Scholar Room 223"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -657,8 +451,754 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OP",
-      "skos:prefLabel": "LPA no Sierra holds"
+      "skos:notation": "OC",
+      "skos:prefLabel": "SASB Cullman Center"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HX",
+      "skos:prefLabel": "HX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QA",
+      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "WL",
+      "skos:prefLabel": "WOLBACH LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NH",
+      "skos:prefLabel": "SASB Rose Main Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NT",
+      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MR",
+      "skos:prefLabel": "Music & Arts Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "GO",
+      "skos:prefLabel": "Google Project (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PG",
+      "skos:prefLabel": "Rare Books"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HY",
+      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "RR",
+      "skos:prefLabel": "ReCAP Reading Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CX",
+      "skos:prefLabel": "CX"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NV",
+      "skos:prefLabel": "LPA TOFT"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PJ",
+      "skos:prefLabel": "Marquand Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CI",
+      "skos:prefLabel": "Interlibary Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AC",
+      "skos:prefLabel": "Avery Cold Vault"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PZ",
+      "skos:prefLabel": "Marquand Library Rare"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EN",
+      "skos:prefLabel": "EN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PQ",
+      "skos:prefLabel": "Plasma Physics Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PF",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NI"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NK"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NN"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NS"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NT"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NV"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NX"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NY"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NZ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PF",
+      "skos:prefLabel": "Firestone Library, Microforms"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JO",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JO",
+      "skos:prefLabel": "JSTOR Restricted"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NM",
+      "skos:prefLabel": "SASB Milstein Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AR",
+      "skos:prefLabel": "Avery Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QN",
+      "skos:prefLabel": "QN"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SP",
+      "skos:prefLabel": "Schomburg Prints & Photographs"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "HS",
+      "skos:prefLabel": "Health Sciences Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QX",
+      "skos:prefLabel": "Firestone Library. Shared"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HJ",
+      "skos:prefLabel": "SSP GOVT DOCUMENTS"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CD",
@@ -672,19 +1212,6 @@
       },
       "skos:notation": "CD",
       "skos:prefLabel": "CD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NE",
-      "skos:prefLabel": "NYPL Inter-Library Loan"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HR",
@@ -744,7 +1271,20 @@
       "skos:prefLabel": "HSL Restricted"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
+      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "IN",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -753,26 +1293,16 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "SA",
-      "skos:prefLabel": "Schomburg Art & Artifacts"
+      "skos:notation": "OM",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PB",
-      "skos:prefLabel": "Firestone Library Use Only"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HY",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
@@ -801,16 +1331,16 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/OC"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
         }
       ],
       "nypl:eddRequestable": {
@@ -818,30 +1348,14 @@
         "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0004"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "HY",
-      "skos:prefLabel": "HARVARD YENCHING LIBRARY"
+      "skos:notation": "NL",
+      "skos:prefLabel": "SASB Restricted"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "BD",
-      "skos:prefLabel": "ReCAP BorrowDirect"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -849,11 +1363,24 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NV",
-      "skos:prefLabel": "LPA TOFT"
+      "skos:notation": "OB",
+      "skos:prefLabel": "SIBL no Sierra holds"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NX",
+      "skos:prefLabel": "Preservation"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -906,40 +1433,81 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "CU",
-      "skos:prefLabel": "CU Standard"
+      "skos:notation": "CR",
+      "skos:prefLabel": "Columbia Restricted"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0001"
+        "@id": "nyplOrg:0002"
       },
-      "skos:notation": "NP",
-      "skos:prefLabel": "LPA"
+      "skos:notation": "GC",
+      "skos:prefLabel": "Government Documents"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HX",
+      "@id": "http://data.nypl.org/recapCustomerCodes/SA",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "HX",
-      "skos:prefLabel": "HX"
+      "skos:notation": "SA",
+      "skos:prefLabel": "Schomburg Art & Artifacts"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/WL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -989,11 +1557,118 @@
       "nypl:owner": {
         "@id": "nyplOrg:0004"
       },
-      "skos:notation": "WL",
-      "skos:prefLabel": "WOLBACH LIBRARY"
+      "skos:notation": "HB",
+      "skos:prefLabel": "BAKER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NG",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NG",
+      "skos:prefLabel": "SASB Art Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SM",
+      "skos:prefLabel": "Schomburg MIRS"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PE",
+      "skos:prefLabel": "Princeton Dark Storage"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AV",
+      "skos:prefLabel": "Avery Classics"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ID",
+      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NP",
+      "skos:prefLabel": "LPA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "ON",
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GS",
+      "skos:prefLabel": "Geoscience Library "
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -1010,6 +1685,365 @@
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HC",
+      "skos:prefLabel": "COUNTWAY LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/HV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "HV",
+      "skos:prefLabel": "Harvard ReCAP Items"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NN",
+      "skos:prefLabel": "LPA Reserve Film and Video"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QC",
+      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EA",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "GE",
+      "skos:prefLabel": "Geology Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BL",
+      "skos:prefLabel": "Barnard Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NE",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NE",
+      "skos:prefLabel": "NYPL Inter-Library Loan"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OW",
+      "skos:prefLabel": "SASB Wertheim Study"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "AD",
+      "skos:prefLabel": "Avery Drawings & Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PA",
+      "skos:prefLabel": "Firestone LIbrary"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OD",
+      "skos:prefLabel": "SASB Scholar Room 217"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UT",
+      "skos:prefLabel": "Burke Library (UTS)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OA",
+      "skos:prefLabel": "SASB Allen Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PW",
+      "skos:prefLabel": "Architecture Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NK",
+      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NY",
+      "skos:prefLabel": "LSC ARCHV"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/OA"
@@ -1037,11 +2071,133 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NQ",
-      "skos:prefLabel": "SASB Restricted"
+      "skos:notation": "JS",
+      "skos:prefLabel": "SIBL De-duping candidates"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PG",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BC",
+      "skos:prefLabel": "Bibliographic Control Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "JN",
+      "skos:prefLabel": "JSTOR Standard"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CJ",
+      "skos:prefLabel": "Journalism Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CS",
+      "skos:prefLabel": "Shipping & Receiving"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/RS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "RS",
+      "skos:prefLabel": "Rare Books & Manuscripts"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CV",
+      "skos:prefLabel": "Butler Media Collection"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1050,11 +2206,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PG",
-      "skos:prefLabel": "Rare Books"
+      "skos:notation": "JP",
+      "skos:prefLabel": "JP"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OW",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1063,8 +2219,213 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "OW",
-      "skos:prefLabel": "SASB Wertheim Study"
+      "skos:notation": "NO",
+      "skos:prefLabel": "SASB Manuscripts and Archives"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CL",
+      "skos:prefLabel": "CL"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PL",
+      "skos:prefLabel": "East Asian Library"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BR",
+      "skos:prefLabel": "BR"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QT",
+      "skos:prefLabel": "Technical Services. 693 (Staff Only)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OZ",
+      "skos:prefLabel": "SASB no Sierra holds"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NJ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NJ",
+      "skos:prefLabel": "SASB Jewish Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OL",
+      "skos:prefLabel": "Media Preservation Lab"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "EV",
+      "skos:prefLabel": "East Asian Vernacular"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/GP",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "GP",
+      "skos:prefLabel": "GP"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NA",
@@ -1124,49 +2485,7 @@
       "skos:prefLabel": "NA"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CP",
-      "skos:prefLabel": "CP"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AC",
-      "skos:prefLabel": "Avery Cold Vault"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MR",
-      "skos:prefLabel": "Music & Arts Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1175,47 +2494,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PM",
-      "skos:prefLabel": "Stokes Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OS",
-      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OM",
-      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AD",
-      "skos:prefLabel": "Avery Drawings & Archives"
+      "skos:notation": "PN",
+      "skos:prefLabel": "Lewis Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HK",
@@ -1272,8 +2552,11 @@
       "skos:prefLabel": "KSG LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SM",
+      "@id": "http://data.nypl.org/recapCustomerCodes/ND",
       "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+      },
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -1281,8 +2564,222 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "SM",
-      "skos:prefLabel": "Schomburg MIRS"
+      "skos:notation": "ND",
+      "skos:prefLabel": "SASB Map Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "MZ",
+      "skos:prefLabel": "ReCAP Coordinator"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/CH",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "CH",
+      "skos:prefLabel": "CH"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "UA",
+      "skos:prefLabel": "UA"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "DL",
+      "skos:prefLabel": "GSD LOEB LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NW",
+      "skos:prefLabel": "Donnell Children's Room"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/QK",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+      },
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "QK",
+      "skos:prefLabel": "Mendel Music Sound & Video Recordings"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NQ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NQ",
+      "skos:prefLabel": "SASB Restricted"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/GUT",
@@ -1337,6 +2834,73 @@
       },
       "skos:notation": "GUT",
       "skos:prefLabel": "GUTMAN LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/MLdupe",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:deliverableTo": [
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        }
+      ],
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0004"
+      },
+      "skos:notation": "MLdupe",
+      "skos:prefLabel": "LOEB MUSIC LIBRARY"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/PB",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "PB",
+      "skos:prefLabel": "Firestone Library Use Only"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/QL",
@@ -1406,20 +2970,20 @@
       "skos:prefLabel": "CABOT SCIENCE LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0001"
       },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
+      "skos:notation": "OI",
+      "skos:prefLabel": "LSC DIU"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AR",
+      "@id": "http://data.nypl.org/recapCustomerCodes/CU",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -1472,86 +3036,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "AR",
-      "skos:prefLabel": "Avery Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CI",
-      "skos:prefLabel": "Interlibary Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NM",
-      "skos:prefLabel": "SASB Milstein Division"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CA",
-      "skos:prefLabel": "Science & Engineering Lib (NWC)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UA",
-      "skos:prefLabel": "UA"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NO",
-      "skos:prefLabel": "SASB Manuscripts and Archives"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/LD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "LD",
-      "skos:prefLabel": "LD"
+      "skos:notation": "CU",
+      "skos:prefLabel": "CU Standard"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/FL",
@@ -1570,30 +3056,7 @@
       "skos:prefLabel": "FINE ARTS LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "OE",
-      "skos:prefLabel": "SASB Scholar Room 223"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PV",
-      "skos:prefLabel": "PV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1602,8 +3065,34 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BL",
-      "skos:prefLabel": "Barnard Library"
+      "skos:notation": "JD",
+      "skos:prefLabel": "JD"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/OS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "OS",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/NR",
@@ -1619,225 +3108,10 @@
       "skos:prefLabel": "SASB Rare Book Division"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JD",
-      "skos:prefLabel": "JD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BU",
-      "skos:prefLabel": "Butler Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QX",
-      "skos:prefLabel": "Firestone Library. Shared"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "OH",
-      "skos:prefLabel": "Oral History"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OL",
-      "skos:prefLabel": "Media Preservation Lab"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CX",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CX",
-      "skos:prefLabel": "CX"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/DL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "DL",
-      "skos:prefLabel": "GSD LOEB LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GC",
-      "skos:prefLabel": "Government Documents"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CV",
-      "skos:prefLabel": "Butler Media Collection"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/IN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "IN",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NN",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
       },
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1846,11 +3120,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NN",
-      "skos:prefLabel": "LPA Reserve Film and Video"
+      "skos:notation": "NS",
+      "skos:prefLabel": "Schomburg Center MARB"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
+      "@id": "http://data.nypl.org/recapCustomerCodes/LE",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1859,11 +3133,37 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "JC",
-      "skos:prefLabel": "JC"
+      "skos:notation": "LE",
+      "skos:prefLabel": "Lehman Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NC",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NC",
+      "skos:prefLabel": "LSC BookOps Cataloging"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/SR",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "SR",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/NB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
@@ -1916,245 +3216,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "JS",
-      "skos:prefLabel": "SIBL De-duping candidates"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PE",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PE",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OB",
-      "skos:prefLabel": "SIBL no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NY",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NY",
-      "skos:prefLabel": "LSC ARCHV"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QA",
-      "skos:prefLabel": "Firestone Library Resource Sharing (Staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OD",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OD",
-      "skos:prefLabel": "SASB Scholar Room 217"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NU",
-      "skos:prefLabel": "LBL Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PF",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NI"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NK"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NN"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NS"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NT"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NV"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NX"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NY"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NZ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PF",
-      "skos:prefLabel": "Firestone Library, Microforms"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HB",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HB",
-      "skos:prefLabel": "BAKER LIBRARY"
+      "skos:notation": "NB",
+      "skos:prefLabel": "SIBL"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/HW",
@@ -2211,214 +3274,20 @@
       "skos:prefLabel": "WIDENER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
       "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NL",
-      "skos:prefLabel": "SASB Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HC",
-      "skos:prefLabel": "COUNTWAY LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CJ",
-      "skos:prefLabel": "Journalism Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EV",
-      "skos:prefLabel": "East Asian Vernacular"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
       },
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "PS",
-      "skos:prefLabel": "Lewis Library Rare"
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/RR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "RR",
-      "skos:prefLabel": "ReCAP Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SW",
+      "@id": "http://data.nypl.org/recapCustomerCodes/RH",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2427,228 +3296,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "SW",
-      "skos:prefLabel": "Social Work Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NW",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NW",
-      "skos:prefLabel": "Donnell Children's Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "AH",
-      "skos:prefLabel": "ANDOVER HARVARD LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NT",
-      "skos:prefLabel": "Permissions & Reproduction Services (SASB)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NH",
-      "skos:prefLabel": "SASB Rose Main Reading Room"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CM",
-      "skos:prefLabel": "Master Microfilm"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/AV",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "AV",
-      "skos:prefLabel": "Avery Classics"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/UT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "UT",
-      "skos:prefLabel": "Burke Library (UTS)"
+      "skos:notation": "RH",
+      "skos:prefLabel": "Human Rights Watch"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/MCZ",
@@ -2705,279 +3354,7 @@
       "skos:prefLabel": "ERNST MAYR LIBRARY (MCZ)"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PN",
-      "skos:prefLabel": "Lewis Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HL",
-      "skos:prefLabel": "HARVARD LAW LIBRARY"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NS",
-      "skos:prefLabel": "Schomburg Center MARB"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "HS",
-      "skos:prefLabel": "Health Sciences Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OC",
-      "skos:prefLabel": "SASB Cullman Center"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GO",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "GO",
-      "skos:prefLabel": "Google Project (deprecated)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/EN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "EN",
-      "skos:prefLabel": "EN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/HJ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0004"
-      },
-      "skos:notation": "HJ",
-      "skos:prefLabel": "SSP GOVT DOCUMENTS"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/MZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "MZ",
-      "skos:prefLabel": "ReCAP Coordinator"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JM",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "JM",
-      "skos:prefLabel": "JM"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QD",
+      "@id": "http://data.nypl.org/recapCustomerCodes/QB",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -2986,34 +3363,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0003"
       },
-      "skos:notation": "QD",
-      "skos:prefLabel": "QD"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "NK",
-      "skos:prefLabel": "BKOPS Barcoding/Special Projects"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ON",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ON",
-      "skos:prefLabel": "SASB Shoichi Noma Scholar Room"
+      "skos:notation": "QB",
+      "skos:prefLabel": "QB"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/MP",
@@ -3027,45 +3378,6 @@
       },
       "skos:notation": "MP",
       "skos:prefLabel": "Monographic Processing"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JQ",
-      "skos:prefLabel": "Princeton Dark Storage"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/SP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "SP",
-      "skos:prefLabel": "Schomburg Prints & Photographs"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "GS",
-      "skos:prefLabel": "Geoscience Library "
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/PT",
@@ -3135,7 +3447,33 @@
       "skos:prefLabel": "TOZZER LIBRARY"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/GE",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0001"
+      },
+      "skos:notation": "NZ",
+      "skos:prefLabel": "SASB Pforzheimer"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BD",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0003"
+      },
+      "skos:notation": "BD",
+      "skos:prefLabel": "ReCAP BorrowDirect"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/JC",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3144,34 +3482,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "GE",
-      "skos:prefLabel": "Geology Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QN",
-      "skos:prefLabel": "QN"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JP",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "JP",
-      "skos:prefLabel": "JP"
+      "skos:notation": "JC",
+      "skos:prefLabel": "JC"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/CF",
@@ -3187,103 +3499,7 @@
       "skos:prefLabel": "Cold Storage Film"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PQ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PQ",
-      "skos:prefLabel": "Plasma Physics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JN",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "JN",
-      "skos:prefLabel": "JSTOR Standard"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NZ",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NI",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3292,146 +3508,11 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NZ",
-      "skos:prefLabel": "SASB Pforzheimer"
+      "skos:notation": "NI",
+      "skos:prefLabel": "LSC Special Formats Processing"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "BR",
-      "skos:prefLabel": "BR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CS",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CS",
-      "skos:prefLabel": "Shipping & Receiving"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PL",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PL",
-      "skos:prefLabel": "East Asian Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ML",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "ML",
-      "skos:prefLabel": "Mathematics Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/QC",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "QC",
-      "skos:prefLabel": "Technical Services, Holdings Management (staff only)"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PH",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PH",
-      "skos:prefLabel": "Mudd Manuscript Library"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/CR",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0002"
-      },
-      "skos:notation": "CR",
-      "skos:prefLabel": "Columbia Restricted"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/NX",
+      "@id": "http://data.nypl.org/recapCustomerCodes/NU",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -3440,104 +3521,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0001"
       },
-      "skos:notation": "NX",
-      "skos:prefLabel": "Preservation"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OZ",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OZ",
-      "skos:prefLabel": "SASB no Sierra holds"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PA",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:deliverableTo": [
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OE"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/OD"
-        }
-      ],
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PA",
-      "skos:prefLabel": "Firestone LIbrary"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/OI",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "OI",
-      "skos:prefLabel": "LSC DIU"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/ID",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0001"
-      },
-      "skos:notation": "ID",
-      "skos:prefLabel": "Inter-Library Loan (deprecated)"
+      "skos:notation": "NU",
+      "skos:prefLabel": "LBL Restricted"
     }
   ]
 }


### PR DESCRIPTION
Remove PF updates outlined in [this ticket](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4269). Note the ticket mentions adding NM but that customer code already was part of the deliverableTo array for PF. I left it for that reason.

Verified by comparing to last tag:
```
(virtualenv) verakahn@MA-CDOAD-057980 scripts % python3 validate-changes.py recapCustomerCodes v2.20                     
Comparing recapCustomerCodes in SCC-4342/add-record-types to v2.20
Keys Added: 0: set()
Keys Deleted: 0
Keys Altered: 0
```

```
Comparing recapCustomerCodes in SCC-4342/revert-PF to master
Keys Added: 0: set()
Keys Deleted: 0
Keys Altered: 1

ALTERED KEY: http://data.nypl.org/recapCustomerCodes/PF
  Attribute(Pos): root['nypl:deliverableTo'][1]
  Removed Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/ND'}
  Attribute(Pos): root['nypl:deliverableTo'][24]
  Removed Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OA'}
  Attribute(Pos): root['nypl:deliverableTo'][25]
  Removed Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OC'}
  Attribute(Pos): root['nypl:deliverableTo'][28]
  Removed Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/ON'}
  Attribute(Pos): root['nypl:deliverableTo'][29]
  Removed Value: {'@id': 'http://data.nypl.org/recapCustomerCodes/OW'}
```