### PR TITLE
[SCC-4777] Bye-bye E-Boo boo-boo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### v2.31
+
+- E-Boo -> E-Book
+
 ### v2.30
 
 - Remove SP, SM, SA, NS as PF deliverableTo location

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Models, mappings, and vocabularies for the NYPL Core ontology.
 
 ### Current Version
 
-v2.30
+v2.31
 
 ## Contributing
 

--- a/vocabularies/csv/formats.csv
+++ b/vocabularies/csv/formats.csv
@@ -28,4 +28,4 @@ v,DVD,DVD
 w,WEB RESOURCE,Web Resource
 x,GAME,Game
 y,MUSIC CD,Music CD
-z,E-BOOK,E-Boo
+z,E-BOOK,E-Book

--- a/vocabularies/json-ld/formats.json
+++ b/vocabularies/json-ld/formats.json
@@ -213,7 +213,7 @@
       "@type": "nypl:Format",
       "skos:altLabel": "E-BOOK",
       "skos:notation": "z",
-      "skos:prefLabel": "E-Boo"
+      "skos:prefLabel": "E-Book"
     }
   ]
 }


### PR DESCRIPTION
* Fixing the infamous typo. Sorry to E-Boo fans around the world.

```
➜  scripts git:(SCC-4777-e-boo) python3 validate-changes.py formats
Comparing formats in SCC-4777-e-boo to master
Keys Added: 0: set()
Keys Deleted: 0
Keys Altered: 1

ALTERED KEY: format:z
  Attribute: root['skos:prefLabel']
  Old Value: E-Boo
  New Value: E-Book
```